### PR TITLE
fix: show actual parse error for malformed XML instead of generic fallback

### DIFF
--- a/src/Editor/ValidationTools.ts
+++ b/src/Editor/ValidationTools.ts
@@ -86,6 +86,16 @@ export class ValidationTools {
     return new Promise((resolve) => {
       try {
         const parser = new DOMParser();
+
+        // Check if user's MEI input is well-formed XML before inserting
+        const wrappedValue = `<root>${value}</root>`;
+        const userDoc = parser.parseFromString(wrappedValue, 'text/xml');
+        const parseError = userDoc.querySelector('parsererror');
+        if (parseError) {
+          resolve([parseError.textContent || 'Malformed XML']);
+          return;
+        }
+
         const meiDoc = parser.parseFromString(meiTemplate, 'text/xml');
         const mei = meiDoc.documentElement;
 


### PR DESCRIPTION
Previously, entering malformed XML in the `mei` column (e.g. `</neume` missing `>`) would show a generic `"Failed to validate MEI"` tooltip for every error. The actual xmllint error never reached the UI.

### Root cause

`validateMEI()` inserts the user's MEI string into an XML document via `layer.innerHTML = value`. On malformed XML, this throws a `SyntaxError` which is silently caught, and the generic fallback message is returned. The validation worker is never invoked.

### Fix

Added a DOMParser well-formedness check before the `innerHTML` insertion. Malformed XML is caught early and the actual parse error is shown in the tooltip. Well-formed XML continues through the existing worker + xmllint pipeline unchanged.

### Before / After

**Before:** every malformed XML error shows the same generic message

<img width="1507" height="822" alt="invalid_test-Network_tab_filter-Worker" src="https://github.com/user-attachments/assets/0a4fb9ad-c2cf-4776-8d94-01175a162fa4" />


**After:** tooltip shows the actual parse error

<img width="1487" height="826" alt="after_malformed_tooltip_missing_bracket" src="https://github.com/user-attachments/assets/dfd4cf02-03bf-42ba-8156-e5e66627c7aa" />



### Testing

- Malformed XML (`<neume>` instead of `</neume>`) → tag mismatch error in tooltip

<img width="700" height="723" alt="after_malformed_tooltip_typo" src="https://github.com/user-attachments/assets/53fc7a0b-7278-4b95-b0c4-3a990c4a70ef" />


- Sample: SQUAREnotation-NEUMElevel (39 rows) → INVALID with real xmllint errors

<img width="964" height="802" alt="after_sample_square_xmllint_error" src="https://github.com/user-attachments/assets/b2798e1a-8caf-4560-8ce0-77280ee81584" />





Related: #133
