### PR TITLE
feat: add faceted classification filter sidebar

### DIFF
--- a/assets/css/hierarchicalFilter.css
+++ b/assets/css/hierarchicalFilter.css
@@ -1,5 +1,7 @@
 /* ----------------------------------------- */
-/* Hierarchical Filter — Toolbar Button
+/* Hierarchical Filter — Toolbar Button      */
+/* Match File / Help style exactly           */
+/* Uses same classes pattern as .navbar-element */
 /* ----------------------------------------- */
 
 .filter-toolbar-btn {
@@ -15,7 +17,6 @@
   height: 100%;
   color: #8675a9;
   font-family: Montserrat, sans-serif;
-  gap: 6px;
 }
 
 .filter-toolbar-btn:hover {
@@ -28,20 +29,17 @@
   color: white;
 }
 
-.filter-toolbar-btn-icon {
-  font-size: 14px;
-  line-height: 1;
+/* Responsive: match .navbar-element media query from style.css */
+@media screen and (max-width: 1023px) {
+  .filter-toolbar-btn {
+    font-size: 10px;
+  }
 }
 
 /* ----------------------------------------- */
-/* Hierarchical Filter — Editor Layout
+/* Hierarchical Filter — Editor Layout       */
 /* ----------------------------------------- */
 
-/*
- * #editor-body-container becomes a flex row.
- * #hot-container takes remaining space (flex: 1).
- * .filter-sidebar sits on the right, width transitions from 0 to 280px.
- */
 #editor-body-container {
   display: flex;
   flex-direction: row;
@@ -49,11 +47,11 @@
 
 #hot-container {
   flex: 1;
-  min-width: 0; /* allow shrinking below content width */
+  min-width: 0;
 }
 
 /* ----------------------------------------- */
-/* Hierarchical Filter — Sidebar
+/* Hierarchical Filter — Sidebar             */
 /* ----------------------------------------- */
 
 .filter-sidebar {
@@ -67,11 +65,31 @@
   height: 91vh;
   background-color: #fff;
   flex-shrink: 0;
+  position: relative;
 }
 
 .filter-sidebar.open {
   width: 280px;
-  border-left: 1px solid #8675a9;
+  border-left: 1px solid #d4d4d4;
+}
+
+/* --- Resize Handle (left edge) --- */
+
+.filter-sidebar-resize-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  background: transparent;
+  z-index: 10;
+  transition: background-color 150ms ease;
+}
+
+.filter-sidebar-resize-handle:hover,
+.filter-sidebar-resize-handle.active {
+  background-color: #8675a9;
 }
 
 /* --- Header --- */
@@ -85,6 +103,7 @@
   flex-shrink: 0;
   min-height: 40px;
   box-sizing: border-box;
+  background-color: #f2f2f2;
 }
 
 .filter-sidebar-title {
@@ -101,9 +120,9 @@
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background-color: #e6e6e6;
+  background-color: transparent;
   color: #888;
-  border: none;
+  border: 1px solid #d4d4d4;
   font-size: 13px;
   line-height: 1;
   display: flex;
@@ -112,10 +131,12 @@
   cursor: pointer;
   flex-shrink: 0;
   font-family: Montserrat, sans-serif;
+  transition: all 150ms ease;
 }
 
 .filter-sidebar-close:hover {
-  background-color: #c3aed6;
+  background-color: #8675a9;
+  border-color: #8675a9;
   color: white;
 }
 
@@ -124,7 +145,7 @@
 .filter-sidebar-body {
   flex: 1;
   overflow-y: auto;
-  padding: 14px;
+  padding: 10px 8px;
   box-sizing: border-box;
 }
 
@@ -141,32 +162,36 @@
 .filter-sidebar-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 10px 14px;
   border-top: 1px solid #e6e6e6;
   flex-shrink: 0;
   min-height: 44px;
   box-sizing: border-box;
   gap: 8px;
+  background-color: #f2f2f2;
 }
 
 .filter-sidebar-btn {
   font-family: Montserrat, sans-serif;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  padding: 5px 16px;
+  padding: 6px 18px;
   border-radius: 4px;
   cursor: pointer;
   border: none;
+  transition: all 150ms ease;
 }
 
 .filter-sidebar-btn-clear {
-  background-color: #f2f2f2;
+  background-color: transparent;
   color: #666;
+  border: 1px solid #d4d4d4;
 }
 
 .filter-sidebar-btn-clear:hover {
   background-color: #e6e6e6;
+  border-color: #bbb;
   color: #333;
 }
 
@@ -176,38 +201,39 @@
 }
 
 .filter-sidebar-btn-apply:hover {
-  background-color: #c3aed6;
+  background-color: #715f96;
 }
 
 /* ----------------------------------------- */
-/* Hierarchical Filter — Tree UI
+/* Hierarchical Filter — Tree UI             */
 /* ----------------------------------------- */
 
 .filter-tree {
   font-family: Montserrat, sans-serif;
-  font-size: 13px;
-  line-height: 1.2;
+  font-size: 12px;
+  line-height: 1.3;
 }
 
 .filter-tree-row {
   display: flex;
   align-items: center;
-  padding: 3px 4px;
-  gap: 4px;
+  padding: 4px 6px;
+  gap: 5px;
   cursor: default;
   border-radius: 3px;
+  transition: background-color 100ms ease;
 }
 
 .filter-tree-row:hover {
-  background-color: #f5f3f8;
+  background-color: #f0f0f0;
 }
 
 .filter-tree-arrow {
   width: 14px;
   flex-shrink: 0;
   text-align: center;
-  font-size: 12px;
-  color: #888;
+  font-size: 11px;
+  color: #bbb;
   user-select: none;
 }
 
@@ -225,6 +251,8 @@
   margin: 0;
   cursor: pointer;
   accent-color: #8675a9;
+  width: 14px;
+  height: 14px;
 }
 
 .filter-tree-label {
@@ -243,9 +271,44 @@
   margin-left: 2px;
 }
 
+/* --- Quality warning with custom CSS tooltip --- */
+
 .filter-tree-quality {
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: 11px;
   margin-left: 2px;
   cursor: help;
+  position: relative;
+  color: #c49000;
+}
+
+.filter-tree-quality-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  background-color: #333;
+  color: #f5f5f5;
+  font-size: 11px;
+  font-weight: 400;
+  padding: 5px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  z-index: 100;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.filter-tree-quality-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  right: 6px;
+  border-width: 4px;
+  border-style: solid;
+  border-color: #333 transparent transparent transparent;
+}
+
+.filter-tree-quality:hover .filter-tree-quality-tooltip {
+  display: block;
 }

--- a/assets/css/hierarchicalFilter.css
+++ b/assets/css/hierarchicalFilter.css
@@ -1,0 +1,180 @@
+/* ----------------------------------------- */
+/* Hierarchical Filter — Toolbar Button
+/* ----------------------------------------- */
+
+.filter-toolbar-btn {
+  display: flex;
+  align-items: center;
+  padding: 0px 1vw;
+  background-color: transparent;
+  font-weight: normal;
+  font-size: 16px;
+  cursor: pointer;
+  border-radius: 6px;
+  overflow: hidden;
+  height: 100%;
+  color: #8675a9;
+  font-family: Montserrat, sans-serif;
+  gap: 6px;
+}
+
+.filter-toolbar-btn:hover {
+  background-color: #c3aed6;
+  color: white;
+}
+
+.filter-toolbar-btn.active {
+  background-color: #8675a9;
+  color: white;
+}
+
+.filter-toolbar-btn-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* ----------------------------------------- */
+/* Hierarchical Filter — Editor Layout
+/* ----------------------------------------- */
+
+/*
+ * #editor-body-container becomes a flex row.
+ * #hot-container takes remaining space (flex: 1).
+ * .filter-sidebar sits on the right, width transitions from 0 to 280px.
+ */
+#editor-body-container {
+  display: flex;
+  flex-direction: row;
+}
+
+#hot-container {
+  flex: 1;
+  min-width: 0; /* allow shrinking below content width */
+}
+
+/* ----------------------------------------- */
+/* Hierarchical Filter — Sidebar
+/* ----------------------------------------- */
+
+.filter-sidebar {
+  width: 0;
+  overflow: hidden;
+  transition: width 250ms ease-out;
+  border-left: none;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 91vh;
+  background-color: #fff;
+  flex-shrink: 0;
+}
+
+.filter-sidebar.open {
+  width: 280px;
+  border-left: 1px solid #8675a9;
+}
+
+/* --- Header --- */
+
+.filter-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #e6e6e6;
+  flex-shrink: 0;
+  min-height: 40px;
+  box-sizing: border-box;
+}
+
+.filter-sidebar-title {
+  font-family: Montserrat, sans-serif;
+  font-weight: 700;
+  font-size: 13px;
+  color: #555;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.filter-sidebar-close {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background-color: #e6e6e6;
+  color: #888;
+  border: none;
+  font-size: 13px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-family: Montserrat, sans-serif;
+}
+
+.filter-sidebar-close:hover {
+  background-color: #c3aed6;
+  color: white;
+}
+
+/* --- Body --- */
+
+.filter-sidebar-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  box-sizing: border-box;
+}
+
+.filter-sidebar-placeholder {
+  color: #aaa;
+  font-family: Montserrat, sans-serif;
+  font-size: 13px;
+  text-align: center;
+  padding-top: 40px;
+}
+
+/* --- Footer --- */
+
+.filter-sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-top: 1px solid #e6e6e6;
+  flex-shrink: 0;
+  min-height: 44px;
+  box-sizing: border-box;
+  gap: 8px;
+}
+
+.filter-sidebar-btn {
+  font-family: Montserrat, sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 5px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: none;
+}
+
+.filter-sidebar-btn-clear {
+  background-color: #f2f2f2;
+  color: #666;
+}
+
+.filter-sidebar-btn-clear:hover {
+  background-color: #e6e6e6;
+  color: #333;
+}
+
+.filter-sidebar-btn-apply {
+  background-color: #8675a9;
+  color: white;
+}
+
+.filter-sidebar-btn-apply:hover {
+  background-color: #c3aed6;
+}

--- a/assets/css/hierarchicalFilter.css
+++ b/assets/css/hierarchicalFilter.css
@@ -178,3 +178,74 @@
 .filter-sidebar-btn-apply:hover {
   background-color: #c3aed6;
 }
+
+/* ----------------------------------------- */
+/* Hierarchical Filter — Tree UI
+/* ----------------------------------------- */
+
+.filter-tree {
+  font-family: Montserrat, sans-serif;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.filter-tree-row {
+  display: flex;
+  align-items: center;
+  padding: 3px 4px;
+  gap: 4px;
+  cursor: default;
+  border-radius: 3px;
+}
+
+.filter-tree-row:hover {
+  background-color: #f5f3f8;
+}
+
+.filter-tree-arrow {
+  width: 14px;
+  flex-shrink: 0;
+  text-align: center;
+  font-size: 12px;
+  color: #888;
+  user-select: none;
+}
+
+.filter-tree-arrow.clickable {
+  cursor: pointer;
+  color: #8675a9;
+}
+
+.filter-tree-arrow.clickable:hover {
+  color: #5a4a78;
+}
+
+.filter-tree-checkbox {
+  flex-shrink: 0;
+  margin: 0;
+  cursor: pointer;
+  accent-color: #8675a9;
+}
+
+.filter-tree-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #333;
+}
+
+.filter-tree-count {
+  flex-shrink: 0;
+  color: #999;
+  font-size: 11px;
+  margin-left: 2px;
+}
+
+.filter-tree-quality {
+  flex-shrink: 0;
+  font-size: 12px;
+  margin-left: 2px;
+  cursor: help;
+}

--- a/dev/server/editor.html
+++ b/dev/server/editor.html
@@ -5,7 +5,10 @@
   <head>
     <title>Cress</title>
     <link rel="stylesheet" href="./Cress-gh/assets/css/style.css" />
-    <link rel="stylesheet" href="./Cress-gh/assets/css/hierarchicalFilter.css" />
+    <link
+      rel="stylesheet"
+      href="./Cress-gh/assets/css/hierarchicalFilter.css"
+    />
     <link rel="shortcut icon" type="image/x-icon" href="favicon.png" />
     <script
       type="text/javascript"

--- a/dev/server/editor.html
+++ b/dev/server/editor.html
@@ -5,6 +5,7 @@
   <head>
     <title>Cress</title>
     <link rel="stylesheet" href="./Cress-gh/assets/css/style.css" />
+    <link rel="stylesheet" href="./Cress-gh/assets/css/hierarchicalFilter.css" />
     <link rel="shortcut icon" type="image/x-icon" href="favicon.png" />
     <script
       type="text/javascript"

--- a/src/Editor/CressTable.ts
+++ b/src/Editor/CressTable.ts
@@ -104,8 +104,22 @@ export class CressTable {
       autoWrapRow: true,
       autoWrapCol: true,
       contextMenu: true,
-      dropdownMenu: true,
+      // === DROPDOWN MENU: custom items, NO filter_by_condition / filter_by_value ===
+      // Filter is handled by the hierarchical filter sidebar instead.
+      dropdownMenu: {
+        items: {
+          col_left: { name: 'Insert column left' },
+          col_right: { name: 'Insert column right' },
+          remove_col: { name: 'Remove column' },
+          separator1: { name: '---------' },
+          clear_column: { name: 'Clear column' },
+          separator2: { name: '---------' },
+          make_read_only: { name: 'Read only' },
+          alignment: {},
+        },
+      },
       filters: true,
+      columnSorting: true,
       className: 'table-menu-btn',
       licenseKey: 'non-commercial-and-evaluation',
       afterLoadData: (_, initialLoad) => {
@@ -187,15 +201,19 @@ export class CressTable {
       this.meiTools.validateMei(this.table, 'afterChange', changes);
     });
   }
+
   // === HIERARCHICAL FILTER ===
   private initFilterSidebar(): void {
+    // Plain text button — matches File / Help style (no arrow icon)
     const filterBtn = document.createElement('div');
     filterBtn.className = 'filter-toolbar-btn';
     filterBtn.id = 'filter-toolbar-btn';
-    filterBtn.innerHTML = '<span class="filter-toolbar-btn-icon">▼</span><span>Filter</span>';
+    filterBtn.textContent = 'Filter';
     filterBtn.title = 'Toggle classification filter panel';
 
-    const bottomRow = document.querySelector('.navbar-main-content-container-bottom');
+    const bottomRow = document.querySelector(
+      '.navbar-main-content-container-bottom',
+    );
     if (bottomRow) {
       bottomRow.appendChild(filterBtn);
     }

--- a/src/Editor/CressTable.ts
+++ b/src/Editor/CressTable.ts
@@ -105,6 +105,7 @@ export class CressTable {
       autoWrapCol: true,
       contextMenu: true,
       dropdownMenu: true,
+      filters: true,
       className: 'table-menu-btn',
       licenseKey: 'non-commercial-and-evaluation',
       afterLoadData: (_, initialLoad) => {
@@ -202,7 +203,7 @@ export class CressTable {
     const editorContainer = document.getElementById('editor-body-container');
     if (!editorContainer) return;
 
-    this.filterSidebar = new FilterSidebar(editorContainer);
+    this.filterSidebar = new FilterSidebar(editorContainer, this.table);
 
     this.filterSidebar.onToggle((isOpen: boolean) => {
       filterBtn.classList.toggle('active', isOpen);

--- a/src/Editor/CressTable.ts
+++ b/src/Editor/CressTable.ts
@@ -7,6 +7,7 @@ import { updateAttachment } from '../Dashboard/Storage';
 import { setSavedStatus } from '../utils/Unsaved';
 import * as Notification from '../utils/Notification';
 import { TableEvent } from '../Types';
+import { FilterSidebar } from './hierarchicalFilter/FilterSidebar';
 
 const changeHooks: TableEvent[] = [
   'afterChange',
@@ -29,6 +30,7 @@ export class CressTable {
   private exportTools: ExportTools;
   private columnTools: ColumnTools;
   private defaultHeader = ['image', 'name', 'classification', 'mei'];
+  private filterSidebar: FilterSidebar | null = null;
 
   constructor(id: string, inputHeader: string[], body: any[]) {
     const container = document.getElementById('hot-container');
@@ -112,6 +114,7 @@ export class CressTable {
 
     this.initFileListener(id, inputHeader, body, this.defaultHeader);
     this.initChangeListener();
+    this.initFilterSidebar();
   }
 
   private initFileListener(
@@ -181,6 +184,37 @@ export class CressTable {
     this.meiTools.validateMei(this.table, 'afterLoadData');
     this.table.addHook('afterChange', (changes, _) => {
       this.meiTools.validateMei(this.table, 'afterChange', changes);
+    });
+  }
+  // === HIERARCHICAL FILTER ===
+  private initFilterSidebar(): void {
+    const filterBtn = document.createElement('div');
+    filterBtn.className = 'filter-toolbar-btn';
+    filterBtn.id = 'filter-toolbar-btn';
+    filterBtn.innerHTML = '<span class="filter-toolbar-btn-icon">▼</span><span>Filter</span>';
+    filterBtn.title = 'Toggle classification filter panel';
+
+    const bottomRow = document.querySelector('.navbar-main-content-container-bottom');
+    if (bottomRow) {
+      bottomRow.appendChild(filterBtn);
+    }
+
+    const editorContainer = document.getElementById('editor-body-container');
+    if (!editorContainer) return;
+
+    this.filterSidebar = new FilterSidebar(editorContainer);
+
+    this.filterSidebar.onToggle((isOpen: boolean) => {
+      filterBtn.classList.toggle('active', isOpen);
+      setTimeout(() => {
+        this.table.refreshDimensions();
+      }, 260);
+    });
+
+    filterBtn.addEventListener('click', () => {
+      if (this.filterSidebar) {
+        this.filterSidebar.toggle();
+      }
     });
   }
 }

--- a/src/Editor/hierarchicalFilter/FilterSidebar.ts
+++ b/src/Editor/hierarchicalFilter/FilterSidebar.ts
@@ -19,6 +19,11 @@ export class FilterSidebar {
   private filterTree: FilterTree | null = null;
   private table: Handsontable | null = null;
 
+  // Resize state
+  private isResizing = false;
+  private boundMouseMove: ((e: MouseEvent) => void) | null = null;
+  private boundMouseUp: (() => void) | null = null;
+
   constructor(container: HTMLElement, table?: Handsontable) {
     this.table = table ?? null;
     this.sidebar = this.createSidebarDOM();
@@ -51,6 +56,7 @@ export class FilterSidebar {
   close(): void {
     if (!this._isOpen) return;
     this._isOpen = false;
+    this.sidebar.style.width = ''; // Clear inline width from resize drag
     this.sidebar.classList.remove('open');
     this.fireToggle();
   }
@@ -68,6 +74,13 @@ export class FilterSidebar {
     this.onToggleCallback = null;
     this.filterTree = null;
     this.table = null;
+    // Clean up resize listeners
+    if (this.boundMouseMove) {
+      document.removeEventListener('mousemove', this.boundMouseMove);
+    }
+    if (this.boundMouseUp) {
+      document.removeEventListener('mouseup', this.boundMouseUp);
+    }
   }
 
   /* ------------------------------------------------------------------ */
@@ -122,12 +135,64 @@ export class FilterSidebar {
   }
 
   /* ------------------------------------------------------------------ */
+  /*  Resize Logic                                                       */
+  /* ------------------------------------------------------------------ */
+
+  private initResize(handle: HTMLDivElement): void {
+    this.boundMouseMove = (e: MouseEvent) => {
+      if (!this.isResizing) return;
+      e.preventDefault();
+
+      // Sidebar is on the right edge. Width = viewport right edge - mouse X.
+      const newWidth = window.innerWidth - e.clientX;
+
+      // Clamp between 200px and 600px
+      const clamped = Math.max(200, Math.min(600, newWidth));
+      this.sidebar.style.width = `${clamped}px`;
+
+      // Refresh Handsontable dimensions live during drag
+      if (this.table) {
+        this.table.refreshDimensions();
+      }
+    };
+
+    this.boundMouseUp = () => {
+      // Always clean up — no isResizing guard, so cleanup is never skipped
+      this.isResizing = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      this.sidebar.style.transition = '';
+      handle.classList.remove('active');
+    };
+
+    handle.addEventListener('mousedown', (e: MouseEvent) => {
+      e.preventDefault();
+      this.isResizing = true;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      handle.classList.add('active');
+
+      // Disable CSS transition during drag for smooth resizing
+      this.sidebar.style.transition = 'none';
+    });
+
+    document.addEventListener('mousemove', this.boundMouseMove);
+    document.addEventListener('mouseup', this.boundMouseUp);
+  }
+
+  /* ------------------------------------------------------------------ */
   /*  DOM Construction                                                   */
   /* ------------------------------------------------------------------ */
 
   private createSidebarDOM(): HTMLDivElement {
     const sidebar = document.createElement('div');
     sidebar.className = 'filter-sidebar';
+
+    // --- Resize handle (left edge of sidebar) ---
+    const resizeHandle = document.createElement('div');
+    resizeHandle.className = 'filter-sidebar-resize-handle';
+    sidebar.appendChild(resizeHandle);
+    this.initResize(resizeHandle);
 
     // --- Header ---
     const header = document.createElement('div');

--- a/src/Editor/hierarchicalFilter/FilterSidebar.ts
+++ b/src/Editor/hierarchicalFilter/FilterSidebar.ts
@@ -1,0 +1,150 @@
+/**
+ * FilterSidebar — UI skeleton for the hierarchical classification filter.
+ *
+ * This class creates and manages the sidebar DOM element. It does NOT
+ * contain tree rendering or filter logic — those will be added in later
+ * stages. Right now it provides:
+ *
+ *   - Sidebar DOM creation (header / body placeholder / footer)
+ *   - toggle() to open/close
+ *   - close() to close only
+ *   - isOpen() to query state
+ *   - onToggle callback so CressTable can call refreshDimensions
+ *   - destroy() for cleanup
+ *
+ * The sidebar element is appended to a given container (expected to be
+ * #editor-body-container). CSS class `.open` controls the width transition.
+ */
+export class FilterSidebar {
+  private sidebar: HTMLDivElement;
+  private _isOpen = false;
+  private onToggleCallback: ((isOpen: boolean) => void) | null = null;
+
+  constructor(container: HTMLElement) {
+    this.sidebar = this.createSidebarDOM();
+    container.appendChild(this.sidebar);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Public API                                                         */
+  /* ------------------------------------------------------------------ */
+
+  /** Toggle sidebar open/closed. */
+  toggle(): void {
+    if (this._isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  /** Open the sidebar. No-op if already open. */
+  open(): void {
+    if (this._isOpen) return;
+    this._isOpen = true;
+    this.sidebar.classList.add('open');
+    this.fireToggle();
+  }
+
+  /** Close the sidebar. No-op if already closed. */
+  close(): void {
+    if (!this._isOpen) return;
+    this._isOpen = false;
+    this.sidebar.classList.remove('open');
+    this.fireToggle();
+  }
+
+  /** Whether the sidebar is currently open. */
+  isOpen(): boolean {
+    return this._isOpen;
+  }
+
+  /**
+   * Register a callback that fires after every open/close.
+   * CressTable uses this to call refreshDimensions after the CSS
+   * transition finishes.
+   */
+  onToggle(cb: (isOpen: boolean) => void): void {
+    this.onToggleCallback = cb;
+  }
+
+  /** Remove the sidebar from the DOM and clean up references. */
+  destroy(): void {
+    this.sidebar.remove();
+    this.onToggleCallback = null;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  DOM Construction                                                   */
+  /* ------------------------------------------------------------------ */
+
+  private createSidebarDOM(): HTMLDivElement {
+    const sidebar = document.createElement('div');
+    sidebar.className = 'filter-sidebar';
+
+    // --- Header ---
+    const header = document.createElement('div');
+    header.className = 'filter-sidebar-header';
+
+    const title = document.createElement('span');
+    title.className = 'filter-sidebar-title';
+    title.textContent = 'Filter classification';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'filter-sidebar-close';
+    closeBtn.textContent = '×';
+    closeBtn.title = 'Close filter panel';
+    closeBtn.addEventListener('click', () => this.close());
+
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+
+    // --- Body (placeholder for now — tree UI goes here in next stage) ---
+    const body = document.createElement('div');
+    body.className = 'filter-sidebar-body';
+
+    const placeholder = document.createElement('div');
+    placeholder.className = 'filter-sidebar-placeholder';
+    placeholder.textContent = 'Tree UI goes here';
+
+    body.appendChild(placeholder);
+
+    // --- Footer ---
+    const footer = document.createElement('div');
+    footer.className = 'filter-sidebar-footer';
+
+    const clearBtn = document.createElement('button');
+    clearBtn.className = 'filter-sidebar-btn filter-sidebar-btn-clear';
+    clearBtn.textContent = 'Clear';
+    clearBtn.addEventListener('click', () => {
+      // Placeholder — will clear filter state in a later stage
+    });
+
+    const applyBtn = document.createElement('button');
+    applyBtn.className = 'filter-sidebar-btn filter-sidebar-btn-apply';
+    applyBtn.textContent = 'Apply';
+    applyBtn.addEventListener('click', () => {
+      // Placeholder — will apply filter in a later stage
+    });
+
+    footer.appendChild(clearBtn);
+    footer.appendChild(applyBtn);
+
+    // --- Assemble ---
+    sidebar.appendChild(header);
+    sidebar.appendChild(body);
+    sidebar.appendChild(footer);
+
+    return sidebar;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Internal                                                           */
+  /* ------------------------------------------------------------------ */
+
+  private fireToggle(): void {
+    if (this.onToggleCallback) {
+      this.onToggleCallback(this._isOpen);
+    }
+  }
+}

--- a/src/Editor/hierarchicalFilter/FilterSidebar.ts
+++ b/src/Editor/hierarchicalFilter/FilterSidebar.ts
@@ -1,35 +1,38 @@
+import Handsontable from 'handsontable';
+import { FilterTree } from './FilterTree';
+
 /**
- * FilterSidebar — UI skeleton for the hierarchical classification filter.
+ * FilterSidebar — manages the sidebar panel for hierarchical classification
+ * filtering. Contains a FilterTree that renders checkboxes from the
+ * classification column data.
  *
- * This class creates and manages the sidebar DOM element. It does NOT
- * contain tree rendering or filter logic — those will be added in later
- * stages. Right now it provides:
- *
- *   - Sidebar DOM creation (header / body placeholder / footer)
- *   - toggle() to open/close
- *   - close() to close only
- *   - isOpen() to query state
- *   - onToggle callback so CressTable can call refreshDimensions
- *   - destroy() for cleanup
- *
- * The sidebar element is appended to a given container (expected to be
- * #editor-body-container). CSS class `.open` controls the width transition.
+ * Public API:
+ *   - toggle() / open() / close() / isOpen()
+ *   - onToggle(cb) — for CressTable to call refreshDimensions
+ *   - destroy()
  */
 export class FilterSidebar {
   private sidebar: HTMLDivElement;
+  private body: HTMLDivElement;
   private _isOpen = false;
   private onToggleCallback: ((isOpen: boolean) => void) | null = null;
+  private filterTree: FilterTree | null = null;
+  private table: Handsontable | null = null;
 
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, table?: Handsontable) {
+    this.table = table ?? null;
     this.sidebar = this.createSidebarDOM();
     container.appendChild(this.sidebar);
+
+    if (this.table) {
+      this.initTree();
+    }
   }
 
   /* ------------------------------------------------------------------ */
   /*  Public API                                                         */
   /* ------------------------------------------------------------------ */
 
-  /** Toggle sidebar open/closed. */
   toggle(): void {
     if (this._isOpen) {
       this.close();
@@ -38,7 +41,6 @@ export class FilterSidebar {
     }
   }
 
-  /** Open the sidebar. No-op if already open. */
   open(): void {
     if (this._isOpen) return;
     this._isOpen = true;
@@ -46,7 +48,6 @@ export class FilterSidebar {
     this.fireToggle();
   }
 
-  /** Close the sidebar. No-op if already closed. */
   close(): void {
     if (!this._isOpen) return;
     this._isOpen = false;
@@ -54,24 +55,70 @@ export class FilterSidebar {
     this.fireToggle();
   }
 
-  /** Whether the sidebar is currently open. */
   isOpen(): boolean {
     return this._isOpen;
   }
 
-  /**
-   * Register a callback that fires after every open/close.
-   * CressTable uses this to call refreshDimensions after the CSS
-   * transition finishes.
-   */
   onToggle(cb: (isOpen: boolean) => void): void {
     this.onToggleCallback = cb;
   }
 
-  /** Remove the sidebar from the DOM and clean up references. */
   destroy(): void {
     this.sidebar.remove();
     this.onToggleCallback = null;
+    this.filterTree = null;
+    this.table = null;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Tree Initialization                                                */
+  /* ------------------------------------------------------------------ */
+
+  private initTree(): void {
+    if (!this.table) return;
+
+    // Read classification column (col index 2) from Handsontable
+    const classifications = this.table.getDataAtCol(2) as (string | null)[];
+
+    // Create tree component inside sidebar body
+    this.filterTree = new FilterTree(this.body);
+    this.filterTree.buildFromData(classifications);
+
+    // Wire Apply callback → Handsontable filter
+    this.filterTree.onApply((rawValues: string[]) => {
+      this.applyFilter(rawValues);
+    });
+
+    // Wire Clear callback → clear Handsontable filter
+    this.filterTree.onClear(() => {
+      this.clearFilter();
+    });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Handsontable Filter Integration                                    */
+  /* ------------------------------------------------------------------ */
+
+  private applyFilter(rawValues: string[]): void {
+    if (!this.table) return;
+
+    const fp = this.table.getPlugin('filters');
+    fp.clearConditions(2);
+
+    if (rawValues.length > 0) {
+      // by_value expects an array of allowed values
+      fp.addCondition(2, 'by_value', [rawValues]);
+    }
+
+    fp.filter();
+  }
+
+  private clearFilter(): void {
+    if (!this.table) return;
+
+    const fp = this.table.getPlugin('filters');
+    fp.clearConditions(2);
+    fp.filter();
   }
 
   /* ------------------------------------------------------------------ */
@@ -99,15 +146,9 @@ export class FilterSidebar {
     header.appendChild(title);
     header.appendChild(closeBtn);
 
-    // --- Body (placeholder for now — tree UI goes here in next stage) ---
-    const body = document.createElement('div');
-    body.className = 'filter-sidebar-body';
-
-    const placeholder = document.createElement('div');
-    placeholder.className = 'filter-sidebar-placeholder';
-    placeholder.textContent = 'Tree UI goes here';
-
-    body.appendChild(placeholder);
+    // --- Body ---
+    this.body = document.createElement('div');
+    this.body.className = 'filter-sidebar-body';
 
     // --- Footer ---
     const footer = document.createElement('div');
@@ -117,14 +158,18 @@ export class FilterSidebar {
     clearBtn.className = 'filter-sidebar-btn filter-sidebar-btn-clear';
     clearBtn.textContent = 'Clear';
     clearBtn.addEventListener('click', () => {
-      // Placeholder — will clear filter state in a later stage
+      if (this.filterTree) {
+        this.filterTree.clear();
+      }
     });
 
     const applyBtn = document.createElement('button');
     applyBtn.className = 'filter-sidebar-btn filter-sidebar-btn-apply';
     applyBtn.textContent = 'Apply';
     applyBtn.addEventListener('click', () => {
-      // Placeholder — will apply filter in a later stage
+      if (this.filterTree) {
+        this.filterTree.apply();
+      }
     });
 
     footer.appendChild(clearBtn);
@@ -132,7 +177,7 @@ export class FilterSidebar {
 
     // --- Assemble ---
     sidebar.appendChild(header);
-    sidebar.appendChild(body);
+    sidebar.appendChild(this.body);
     sidebar.appendChild(footer);
 
     return sidebar;

--- a/src/Editor/hierarchicalFilter/FilterTree.ts
+++ b/src/Editor/hierarchicalFilter/FilterTree.ts
@@ -43,7 +43,7 @@ export class FilterTree {
   buildFromData(classifications: (string | null | undefined)[]): void {
     this.root = parseClassifications(classifications);
     this.stateMap.clear();
-    this.initStates(this.root, '');
+    this.initStates(this.root, '', 0);
     this.render();
   }
 
@@ -78,8 +78,16 @@ export class FilterTree {
 
   /** Trigger apply with current selection. */
   apply(): void {
+    const selected = this.getSelectedRawValues();
+
+    // Empty selection = Clear (instead of showing 0 rows)
+    if (selected.length === 0) {
+      this.clear();
+      return;
+    }
+
     if (this.applyCallback) {
-      this.applyCallback(this.getSelectedRawValues());
+      this.applyCallback(selected);
     }
   }
 
@@ -94,16 +102,18 @@ export class FilterTree {
     return parentPath ? `${parentPath}.${node.label}` : node.label;
   }
 
-  private initStates(node: TreeNode, parentPath: string): void {
+  /** Initialize states. depth=0 is synthetic root, depth=1 = top-level children (expanded by default). */
+  private initStates(node: TreeNode, parentPath: string, depth: number): void {
     for (const [, child] of node.children) {
       const key = this.getStateKey(child, parentPath);
       if (!this.stateMap.has(key)) {
         this.stateMap.set(key, {
-          expanded: false,
+          // First-level nodes (depth 1, i.e. direct children of root) default expanded
+          expanded: depth === 0,
           checked: 'none',
         });
       }
-      this.initStates(child, key);
+      this.initStates(child, key, depth + 1);
     }
   }
 
@@ -133,7 +143,11 @@ export class FilterTree {
     this.render();
   }
 
-  private propagateDown(node: TreeNode, parentKey: string, checked: CheckState): void {
+  private propagateDown(
+    node: TreeNode,
+    parentKey: string,
+    checked: CheckState,
+  ): void {
     for (const [, child] of node.children) {
       const childKey = this.getStateKey(child, parentKey);
       const childState = this.getState(childKey);
@@ -161,14 +175,20 @@ export class FilterTree {
     // Find parent node and recompute its checked state from children
     const parentNode = this.findNode(parentKey);
     if (parentNode) {
-      parentState.checked = this.computeCheckFromChildren(parentNode, parentKey);
+      parentState.checked = this.computeCheckFromChildren(
+        parentNode,
+        parentKey,
+      );
     }
 
     // Continue up
     this.propagateUp(parentKey);
   }
 
-  private computeCheckFromChildren(node: TreeNode, nodeKey: string): CheckState {
+  private computeCheckFromChildren(
+    node: TreeNode,
+    nodeKey: string,
+  ): CheckState {
     let allChecked = true;
     let noneChecked = true;
 
@@ -202,7 +222,11 @@ export class FilterTree {
     return cursor;
   }
 
-  private collectSelected(node: TreeNode, parentKey: string, result: string[]): void {
+  private collectSelected(
+    node: TreeNode,
+    parentKey: string,
+    result: string[],
+  ): void {
     for (const [, child] of node.children) {
       const key = this.getStateKey(child, parentKey);
       const state = this.getState(key);
@@ -225,6 +249,29 @@ export class FilterTree {
     for (const [, child] of node.children) {
       this.collectAllLeafRawValues(child, result);
     }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Quality flag helpers                                               */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Decide whether to show a quality warning for this node.
+   * Only show for flags that represent real data issues (hasEnDash).
+   * hasNewline is a systemic parseWORD artifact — not a user error.
+   */
+  private shouldShowQuality(node: TreeNode): boolean {
+    if (!node.quality) return false;
+    return !!node.quality.hasEnDash;
+  }
+
+  private getQualityTooltip(node: TreeNode): string {
+    if (!node.quality) return '';
+    const flags: string[] = [];
+    if (node.quality.hasEnDash)
+      flags.push('contains en-dash (–) — possible typo');
+    if (node.quality.hasTrailingSpace) flags.push('has trailing whitespace');
+    return flags.join('; ');
   }
 
   /* ------------------------------------------------------------------ */
@@ -265,7 +312,7 @@ export class FilterTree {
     // --- Row ---
     const row = document.createElement('div');
     row.className = 'filter-tree-row';
-    row.style.paddingLeft = `${depth * 16}px`;
+    row.style.paddingLeft = `${8 + depth * 18}px`;
 
     // --- Expand/collapse arrow ---
     const arrow = document.createElement('span');
@@ -299,7 +346,6 @@ export class FilterTree {
     const label = document.createElement('span');
     label.className = 'filter-tree-label';
     label.textContent = node.label;
-    label.title = node.fullPath || node.label; // hover shows full path
     row.appendChild(label);
 
     // --- Count badge ---
@@ -308,13 +354,18 @@ export class FilterTree {
     count.textContent = `(${node.count})`;
     row.appendChild(count);
 
-    // --- Quality warning ---
-    if (node.quality) {
+    // --- Quality warning (only for real data issues, not systemic \n) ---
+    if (this.shouldShowQuality(node)) {
       const warn = document.createElement('span');
       warn.className = 'filter-tree-quality';
       warn.textContent = '⚠';
-      const flags = Object.keys(node.quality).join(', ');
-      warn.title = `Data quality: ${flags}`;
+
+      // Custom CSS tooltip (more reliable than title attr on small elements)
+      const tooltip = document.createElement('span');
+      tooltip.className = 'filter-tree-quality-tooltip';
+      tooltip.textContent = this.getQualityTooltip(node);
+      warn.appendChild(tooltip);
+
       row.appendChild(warn);
     }
 

--- a/src/Editor/hierarchicalFilter/FilterTree.ts
+++ b/src/Editor/hierarchicalFilter/FilterTree.ts
@@ -1,0 +1,331 @@
+import { TreeNode, UNCATEGORIZED_KEY } from './types';
+import { parseClassifications } from './classificationTreeParser';
+
+/**
+ * Checkbox state for tree nodes.
+ * - 'all': node and all descendants are selected
+ * - 'none': node and all descendants are unselected
+ * - 'some': some descendants are selected (indeterminate)
+ */
+type CheckState = 'all' | 'none' | 'some';
+
+interface NodeState {
+  expanded: boolean;
+  checked: CheckState;
+}
+
+/**
+ * FilterTree — renders a hierarchical classification tree with checkboxes
+ * inside a container element (the sidebar body).
+ *
+ * Usage:
+ *   const tree = new FilterTree(bodyEl);
+ *   tree.buildFromData(classifications);  // string[]
+ *   tree.onApply((rawValues) => { ... }); // selected leaf rawValues
+ *   tree.clear();                         // reset all checkboxes
+ */
+export class FilterTree {
+  private container: HTMLElement;
+  private root: TreeNode | null = null;
+  private stateMap: Map<string, NodeState> = new Map();
+  private applyCallback: ((rawValues: string[]) => void) | null = null;
+  private clearCallback: (() => void) | null = null;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Public API                                                         */
+  /* ------------------------------------------------------------------ */
+
+  /** Build the tree from classification column data and render. */
+  buildFromData(classifications: (string | null | undefined)[]): void {
+    this.root = parseClassifications(classifications);
+    this.stateMap.clear();
+    this.initStates(this.root, '');
+    this.render();
+  }
+
+  /** Register callback for Apply button. Receives array of rawValues. */
+  onApply(cb: (rawValues: string[]) => void): void {
+    this.applyCallback = cb;
+  }
+
+  /** Register callback for Clear button. */
+  onClear(cb: () => void): void {
+    this.clearCallback = cb;
+  }
+
+  /** Reset all checkboxes to unchecked and re-render. */
+  clear(): void {
+    for (const state of this.stateMap.values()) {
+      state.checked = 'none';
+    }
+    this.render();
+    if (this.clearCallback) {
+      this.clearCallback();
+    }
+  }
+
+  /** Collect rawValues of all selected leaves. */
+  getSelectedRawValues(): string[] {
+    if (!this.root) return [];
+    const result: string[] = [];
+    this.collectSelected(this.root, '', result);
+    return result;
+  }
+
+  /** Trigger apply with current selection. */
+  apply(): void {
+    if (this.applyCallback) {
+      this.applyCallback(this.getSelectedRawValues());
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  State Management                                                   */
+  /* ------------------------------------------------------------------ */
+
+  private getStateKey(node: TreeNode, parentPath: string): string {
+    // Use fullPath for nodes that have it, otherwise build from parent
+    if (node.fullPath) return node.fullPath;
+    if (node.label === UNCATEGORIZED_KEY) return UNCATEGORIZED_KEY;
+    return parentPath ? `${parentPath}.${node.label}` : node.label;
+  }
+
+  private initStates(node: TreeNode, parentPath: string): void {
+    for (const [, child] of node.children) {
+      const key = this.getStateKey(child, parentPath);
+      if (!this.stateMap.has(key)) {
+        this.stateMap.set(key, {
+          expanded: false,
+          checked: 'none',
+        });
+      }
+      this.initStates(child, key);
+    }
+  }
+
+  private getState(key: string): NodeState {
+    let state = this.stateMap.get(key);
+    if (!state) {
+      state = { expanded: false, checked: 'none' };
+      this.stateMap.set(key, state);
+    }
+    return state;
+  }
+
+  /** Toggle a node's checked state and propagate to children/parents. */
+  private toggleCheck(node: TreeNode, key: string): void {
+    const state = this.getState(key);
+    const newChecked: CheckState = state.checked === 'all' ? 'none' : 'all';
+
+    // Set this node
+    state.checked = newChecked;
+
+    // Propagate down: all descendants match parent
+    this.propagateDown(node, key, newChecked);
+
+    // Propagate up: recompute ancestors
+    this.propagateUp(key);
+
+    this.render();
+  }
+
+  private propagateDown(node: TreeNode, parentKey: string, checked: CheckState): void {
+    for (const [, child] of node.children) {
+      const childKey = this.getStateKey(child, parentKey);
+      const childState = this.getState(childKey);
+      childState.checked = checked;
+      this.propagateDown(child, childKey, checked);
+    }
+  }
+
+  private propagateUp(key: string): void {
+    // Walk up by stripping last segment
+    const dotIdx = key.lastIndexOf('.');
+    if (dotIdx === -1) {
+      // Top-level node, check if it's UNCATEGORIZED_KEY
+      if (key === UNCATEGORIZED_KEY) return;
+      return; // no parent to update
+    }
+
+    const parentKey = key.substring(0, dotIdx);
+    const parentState = this.stateMap.get(parentKey);
+    if (!parentState) {
+      // Parent might be a synthetic root child — try without dot
+      return;
+    }
+
+    // Find parent node and recompute its checked state from children
+    const parentNode = this.findNode(parentKey);
+    if (parentNode) {
+      parentState.checked = this.computeCheckFromChildren(parentNode, parentKey);
+    }
+
+    // Continue up
+    this.propagateUp(parentKey);
+  }
+
+  private computeCheckFromChildren(node: TreeNode, nodeKey: string): CheckState {
+    let allChecked = true;
+    let noneChecked = true;
+
+    for (const [, child] of node.children) {
+      const childKey = this.getStateKey(child, nodeKey);
+      const childState = this.getState(childKey);
+      if (childState.checked !== 'all') allChecked = false;
+      if (childState.checked !== 'none') noneChecked = false;
+    }
+
+    if (allChecked) return 'all';
+    if (noneChecked) return 'none';
+    return 'some';
+  }
+
+  private findNode(key: string): TreeNode | null {
+    if (!this.root) return null;
+
+    // Handle UNCATEGORIZED_KEY
+    if (key === UNCATEGORIZED_KEY) {
+      return this.root.children.get(UNCATEGORIZED_KEY) ?? null;
+    }
+
+    const parts = key.split('.');
+    let cursor: TreeNode = this.root;
+    for (const part of parts) {
+      const child = cursor.children.get(part);
+      if (!child) return null;
+      cursor = child;
+    }
+    return cursor;
+  }
+
+  private collectSelected(node: TreeNode, parentKey: string, result: string[]): void {
+    for (const [, child] of node.children) {
+      const key = this.getStateKey(child, parentKey);
+      const state = this.getState(key);
+
+      if (state.checked === 'all') {
+        // Collect all leaf rawValues under this subtree
+        this.collectAllLeafRawValues(child, result);
+      } else if (state.checked === 'some') {
+        // Partially checked — recurse into children
+        this.collectSelected(child, key, result);
+      }
+      // 'none' — skip entirely
+    }
+  }
+
+  private collectAllLeafRawValues(node: TreeNode, result: string[]): void {
+    if (node.isLeaf && node.rawValue !== null) {
+      result.push(node.rawValue);
+    }
+    for (const [, child] of node.children) {
+      this.collectAllLeafRawValues(child, result);
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Rendering                                                          */
+  /* ------------------------------------------------------------------ */
+
+  private render(): void {
+    this.container.innerHTML = '';
+
+    if (!this.root || this.root.children.size === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'filter-sidebar-placeholder';
+      empty.textContent = 'No classification data';
+      this.container.appendChild(empty);
+      return;
+    }
+
+    const list = document.createElement('div');
+    list.className = 'filter-tree';
+
+    for (const [, child] of this.root.children) {
+      const key = this.getStateKey(child, '');
+      this.renderNode(child, key, list, 0);
+    }
+
+    this.container.appendChild(list);
+  }
+
+  private renderNode(
+    node: TreeNode,
+    key: string,
+    parent: HTMLElement,
+    depth: number,
+  ): void {
+    const state = this.getState(key);
+    const hasChildren = node.children.size > 0;
+
+    // --- Row ---
+    const row = document.createElement('div');
+    row.className = 'filter-tree-row';
+    row.style.paddingLeft = `${depth * 16}px`;
+
+    // --- Expand/collapse arrow ---
+    const arrow = document.createElement('span');
+    arrow.className = 'filter-tree-arrow';
+    if (hasChildren) {
+      arrow.textContent = state.expanded ? '▾' : '▸';
+      arrow.classList.add('clickable');
+      arrow.addEventListener('click', (e) => {
+        e.stopPropagation();
+        state.expanded = !state.expanded;
+        this.render();
+      });
+    } else {
+      arrow.textContent = ' ';
+    }
+    row.appendChild(arrow);
+
+    // --- Checkbox ---
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'filter-tree-checkbox';
+    checkbox.checked = state.checked === 'all';
+    checkbox.indeterminate = state.checked === 'some';
+    checkbox.addEventListener('change', (e) => {
+      e.stopPropagation();
+      this.toggleCheck(node, key);
+    });
+    row.appendChild(checkbox);
+
+    // --- Label ---
+    const label = document.createElement('span');
+    label.className = 'filter-tree-label';
+    label.textContent = node.label;
+    label.title = node.fullPath || node.label; // hover shows full path
+    row.appendChild(label);
+
+    // --- Count badge ---
+    const count = document.createElement('span');
+    count.className = 'filter-tree-count';
+    count.textContent = `(${node.count})`;
+    row.appendChild(count);
+
+    // --- Quality warning ---
+    if (node.quality) {
+      const warn = document.createElement('span');
+      warn.className = 'filter-tree-quality';
+      warn.textContent = '⚠';
+      const flags = Object.keys(node.quality).join(', ');
+      warn.title = `Data quality: ${flags}`;
+      row.appendChild(warn);
+    }
+
+    parent.appendChild(row);
+
+    // --- Children (if expanded) ---
+    if (hasChildren && state.expanded) {
+      for (const [, child] of node.children) {
+        const childKey = this.getStateKey(child, key);
+        this.renderNode(child, childKey, parent, depth + 1);
+      }
+    }
+  }
+}

--- a/src/Editor/hierarchicalFilter/classificationTreeParser.ts
+++ b/src/Editor/hierarchicalFilter/classificationTreeParser.ts
@@ -1,8 +1,4 @@
-import {
-  TreeNode,
-  UNCATEGORIZED_KEY,
-  UNCATEGORIZED_LABEL,
-} from './types';
+import { TreeNode, UNCATEGORIZED_KEY, UNCATEGORIZED_LABEL } from './types';
 
 /**
  * Parse an array of classification strings (one per data row) into a tree.
@@ -37,10 +33,7 @@ export function parseClassifications(
   return root;
 }
 
-function insertOne(
-  root: TreeNode,
-  rawInput: string | null | undefined,
-): void {
+function insertOne(root: TreeNode, rawInput: string | null | undefined): void {
   // 1. Empty / null / whitespace-only → uncategorized
   if (rawInput == null || rawInput.trim() === '') {
     const bucket = ensureChild(root, UNCATEGORIZED_KEY, UNCATEGORIZED_LABEL);
@@ -83,11 +76,7 @@ function insertOne(
   propagateCount(root, tokens);
 }
 
-function ensureChild(
-  parent: TreeNode,
-  key: string,
-  label: string,
-): TreeNode {
+function ensureChild(parent: TreeNode, key: string, label: string): TreeNode {
   const existing = parent.children.get(key);
   if (existing) return existing;
 
@@ -114,7 +103,7 @@ function markAsLeaf(node: TreeNode, rawValue: string): void {
   // Set quality flags. Only set when true (absence = clean, per types.ts).
   const q: NonNullable<TreeNode['quality']> = node.quality ?? {};
   if (rawValue.includes('\n')) q.hasNewline = true;
-  if (rawValue.includes('–')) q.hasEnDash = true;       // U+2013 EN DASH
+  if (rawValue.includes('–')) q.hasEnDash = true; // U+2013 EN DASH
   if (rawValue !== rawValue.trim()) q.hasTrailingSpace = true;
   if (Object.keys(q).length > 0) node.quality = q;
 }

--- a/src/Editor/hierarchicalFilter/classificationTreeParser.ts
+++ b/src/Editor/hierarchicalFilter/classificationTreeParser.ts
@@ -1,0 +1,186 @@
+import {
+  TreeNode,
+  UNCATEGORIZED_KEY,
+  UNCATEGORIZED_LABEL,
+} from './types';
+
+/**
+ * Parse an array of classification strings (one per data row) into a tree.
+ *
+ * Design principles (see BACKLOG §1.3):
+ *   - Split by '.'
+ *   - Leaves = full trimmed classification strings that appear in the data
+ *   - No normalization: no lowercase, no _ / . merging, no typo fixing
+ *   - Preserve original raw string on leaf for Handsontable filter
+ *   - Empty/null/whitespace → UNCATEGORIZED bucket
+ *   - En-dash and other suspicious chars → quality flags, but do not split
+ *
+ * @param values  classification column values, one per row
+ * @returns       synthetic root TreeNode; top-level categories are its children
+ */
+export function parseClassifications(
+  values: ReadonlyArray<string | null | undefined>,
+): TreeNode {
+  const root: TreeNode = {
+    label: '',
+    fullPath: '',
+    rawValue: null,
+    isLeaf: false,
+    children: new Map(),
+    count: 0,
+  };
+
+  for (const raw of values) {
+    insertOne(root, raw);
+  }
+
+  return root;
+}
+
+function insertOne(
+  root: TreeNode,
+  rawInput: string | null | undefined,
+): void {
+  // 1. Empty / null / whitespace-only → uncategorized
+  if (rawInput == null || rawInput.trim() === '') {
+    const bucket = ensureChild(root, UNCATEGORIZED_KEY, UNCATEGORIZED_LABEL);
+    markAsLeaf(bucket, rawInput ?? '');
+    propagateCount(root, [UNCATEGORIZED_KEY]);
+    return;
+  }
+
+  // 2. Trim surrounding whitespace (including trailing \n) for the CLEANED view.
+  //    rawInput stays original and becomes the leaf's rawValue.
+  const cleaned = rawInput.trim();
+
+  // 3. Split by '.'; drop empty segments (handles '..', trailing '.', etc.)
+  const tokens = cleaned.split('.').filter((t) => t.length > 0);
+
+  // 4. Degenerate case: string was ONLY dots (e.g. "..." or ".")
+  //    → also goes to uncategorized, but preserve the raw value.
+  if (tokens.length === 0) {
+    const bucket = ensureChild(root, UNCATEGORIZED_KEY, UNCATEGORIZED_LABEL);
+    markAsLeaf(bucket, rawInput);
+    propagateCount(root, [UNCATEGORIZED_KEY]);
+    return;
+  }
+
+  // 5. Walk/build the tree path, creating middle nodes as needed.
+  let cursor = root;
+  const pathSoFar: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    pathSoFar.push(token);
+    cursor = ensureChild(cursor, token, token);
+    cursor.fullPath = pathSoFar.join('.');
+  }
+
+  // 6. The final cursor is a LEAF. This path = an actual data entry.
+  //    (It may already have children, in which case this is a self-node.)
+  markAsLeaf(cursor, rawInput);
+
+  // 7. Propagate count to every ancestor on the path.
+  propagateCount(root, tokens);
+}
+
+function ensureChild(
+  parent: TreeNode,
+  key: string,
+  label: string,
+): TreeNode {
+  const existing = parent.children.get(key);
+  if (existing) return existing;
+
+  const node: TreeNode = {
+    label,
+    fullPath: '',
+    rawValue: null,
+    isLeaf: false,
+    children: new Map(),
+    count: 0,
+  };
+  parent.children.set(key, node);
+  return node;
+}
+
+function markAsLeaf(node: TreeNode, rawValue: string): void {
+  node.isLeaf = true;
+  // If multiple rows share the same classification string, keep the first
+  // raw value. They're equal-after-trim anyway; the filter matches on
+  // exact string and Handsontable will select all matching rows.
+  if (node.rawValue === null) {
+    node.rawValue = rawValue;
+  }
+  // Set quality flags. Only set when true (absence = clean, per types.ts).
+  const q: NonNullable<TreeNode['quality']> = node.quality ?? {};
+  if (rawValue.includes('\n')) q.hasNewline = true;
+  if (rawValue.includes('–')) q.hasEnDash = true;       // U+2013 EN DASH
+  if (rawValue !== rawValue.trim()) q.hasTrailingSpace = true;
+  if (Object.keys(q).length > 0) node.quality = q;
+}
+
+function propagateCount(root: TreeNode, tokens: ReadonlyArray<string>): void {
+  // Every node on the path (including the leaf) counts this row once.
+  // Root is a synthetic container; we increment its count too so caller
+  // can read the grand total from root.count.
+  root.count += 1;
+
+  let cursor = root;
+  for (const token of tokens) {
+    const child = cursor.children.get(token);
+    if (!child) return; // should never happen — we just built this path
+    child.count += 1;
+    cursor = child;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Debug helpers (used by unit tests + for pretty printing in reviews)       */
+/* -------------------------------------------------------------------------- */
+
+export interface DumpOptions {
+  showCounts?: boolean;
+  showRawValue?: boolean;
+  showQuality?: boolean;
+  indent?: string;
+}
+
+/**
+ * Render a TreeNode as a human-readable indented string. For test output
+ * and manual review. Does NOT sort — preserves insertion order.
+ */
+export function dumpTree(
+  node: TreeNode,
+  options: DumpOptions = {},
+  depth = 0,
+): string {
+  const {
+    showCounts = true,
+    showRawValue = false,
+    showQuality = true,
+    indent = '  ',
+  } = options;
+
+  const lines: string[] = [];
+
+  if (depth > 0) {
+    const prefix = indent.repeat(depth - 1);
+    const marker = node.isLeaf ? '•' : '▸';
+    const count = showCounts ? ` (${node.count})` : '';
+    const raw =
+      showRawValue && node.isLeaf && node.rawValue !== null
+        ? `  rawValue=${JSON.stringify(node.rawValue)}`
+        : '';
+    const q =
+      showQuality && node.quality
+        ? `  ⚠️ ${Object.keys(node.quality).join(',')}`
+        : '';
+    lines.push(`${prefix}${marker} ${node.label}${count}${raw}${q}`);
+  }
+
+  for (const child of node.children.values()) {
+    lines.push(dumpTree(child, options, depth + 1));
+  }
+
+  return lines.join('\n');
+}

--- a/src/Editor/hierarchicalFilter/hierarchicalFilter.css
+++ b/src/Editor/hierarchicalFilter/hierarchicalFilter.css
@@ -1,5 +1,7 @@
 /* ----------------------------------------- */
-/* Hierarchical Filter — Toolbar Button
+/* Hierarchical Filter — Toolbar Button      */
+/* Match File / Help style exactly           */
+/* Uses same classes pattern as .navbar-element */
 /* ----------------------------------------- */
 
 .filter-toolbar-btn {
@@ -15,7 +17,6 @@
   height: 100%;
   color: #8675a9;
   font-family: Montserrat, sans-serif;
-  gap: 6px;
 }
 
 .filter-toolbar-btn:hover {
@@ -28,20 +29,17 @@
   color: white;
 }
 
-.filter-toolbar-btn-icon {
-  font-size: 14px;
-  line-height: 1;
+/* Responsive: match .navbar-element media query from style.css */
+@media screen and (max-width: 1023px) {
+  .filter-toolbar-btn {
+    font-size: 10px;
+  }
 }
 
 /* ----------------------------------------- */
-/* Hierarchical Filter — Editor Layout
+/* Hierarchical Filter — Editor Layout       */
 /* ----------------------------------------- */
 
-/*
- * #editor-body-container becomes a flex row.
- * #hot-container takes remaining space (flex: 1).
- * .filter-sidebar sits on the right, width transitions from 0 to 280px.
- */
 #editor-body-container {
   display: flex;
   flex-direction: row;
@@ -49,11 +47,11 @@
 
 #hot-container {
   flex: 1;
-  min-width: 0; /* allow shrinking below content width */
+  min-width: 0;
 }
 
 /* ----------------------------------------- */
-/* Hierarchical Filter — Sidebar
+/* Hierarchical Filter — Sidebar             */
 /* ----------------------------------------- */
 
 .filter-sidebar {
@@ -67,11 +65,31 @@
   height: 91vh;
   background-color: #fff;
   flex-shrink: 0;
+  position: relative;
 }
 
 .filter-sidebar.open {
   width: 280px;
-  border-left: 1px solid #8675a9;
+  border-left: 1px solid #d4d4d4;
+}
+
+/* --- Resize Handle (left edge) --- */
+
+.filter-sidebar-resize-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  background: transparent;
+  z-index: 10;
+  transition: background-color 150ms ease;
+}
+
+.filter-sidebar-resize-handle:hover,
+.filter-sidebar-resize-handle.active {
+  background-color: #8675a9;
 }
 
 /* --- Header --- */
@@ -85,6 +103,7 @@
   flex-shrink: 0;
   min-height: 40px;
   box-sizing: border-box;
+  background-color: #f2f2f2;
 }
 
 .filter-sidebar-title {
@@ -101,9 +120,9 @@
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  background-color: #e6e6e6;
+  background-color: transparent;
   color: #888;
-  border: none;
+  border: 1px solid #d4d4d4;
   font-size: 13px;
   line-height: 1;
   display: flex;
@@ -112,10 +131,12 @@
   cursor: pointer;
   flex-shrink: 0;
   font-family: Montserrat, sans-serif;
+  transition: all 150ms ease;
 }
 
 .filter-sidebar-close:hover {
-  background-color: #c3aed6;
+  background-color: #8675a9;
+  border-color: #8675a9;
   color: white;
 }
 
@@ -124,7 +145,7 @@
 .filter-sidebar-body {
   flex: 1;
   overflow-y: auto;
-  padding: 14px;
+  padding: 10px 8px;
   box-sizing: border-box;
 }
 
@@ -141,32 +162,36 @@
 .filter-sidebar-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 10px 14px;
   border-top: 1px solid #e6e6e6;
   flex-shrink: 0;
   min-height: 44px;
   box-sizing: border-box;
   gap: 8px;
+  background-color: #f2f2f2;
 }
 
 .filter-sidebar-btn {
   font-family: Montserrat, sans-serif;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  padding: 5px 16px;
+  padding: 6px 18px;
   border-radius: 4px;
   cursor: pointer;
   border: none;
+  transition: all 150ms ease;
 }
 
 .filter-sidebar-btn-clear {
-  background-color: #f2f2f2;
+  background-color: transparent;
   color: #666;
+  border: 1px solid #d4d4d4;
 }
 
 .filter-sidebar-btn-clear:hover {
   background-color: #e6e6e6;
+  border-color: #bbb;
   color: #333;
 }
 
@@ -176,38 +201,39 @@
 }
 
 .filter-sidebar-btn-apply:hover {
-  background-color: #c3aed6;
+  background-color: #715f96;
 }
 
 /* ----------------------------------------- */
-/* Hierarchical Filter — Tree UI
+/* Hierarchical Filter — Tree UI             */
 /* ----------------------------------------- */
 
 .filter-tree {
   font-family: Montserrat, sans-serif;
-  font-size: 13px;
-  line-height: 1.2;
+  font-size: 12px;
+  line-height: 1.3;
 }
 
 .filter-tree-row {
   display: flex;
   align-items: center;
-  padding: 3px 4px;
-  gap: 4px;
+  padding: 4px 6px;
+  gap: 5px;
   cursor: default;
   border-radius: 3px;
+  transition: background-color 100ms ease;
 }
 
 .filter-tree-row:hover {
-  background-color: #f5f3f8;
+  background-color: #f0f0f0;
 }
 
 .filter-tree-arrow {
   width: 14px;
   flex-shrink: 0;
   text-align: center;
-  font-size: 12px;
-  color: #888;
+  font-size: 11px;
+  color: #bbb;
   user-select: none;
 }
 
@@ -225,6 +251,8 @@
   margin: 0;
   cursor: pointer;
   accent-color: #8675a9;
+  width: 14px;
+  height: 14px;
 }
 
 .filter-tree-label {
@@ -243,9 +271,44 @@
   margin-left: 2px;
 }
 
+/* --- Quality warning with custom CSS tooltip --- */
+
 .filter-tree-quality {
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: 11px;
   margin-left: 2px;
   cursor: help;
+  position: relative;
+  color: #c49000;
+}
+
+.filter-tree-quality-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  background-color: #333;
+  color: #f5f5f5;
+  font-size: 11px;
+  font-weight: 400;
+  padding: 5px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  z-index: 100;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.filter-tree-quality-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  right: 6px;
+  border-width: 4px;
+  border-style: solid;
+  border-color: #333 transparent transparent transparent;
+}
+
+.filter-tree-quality:hover .filter-tree-quality-tooltip {
+  display: block;
 }

--- a/src/Editor/hierarchicalFilter/hierarchicalFilter.css
+++ b/src/Editor/hierarchicalFilter/hierarchicalFilter.css
@@ -1,0 +1,180 @@
+/* ----------------------------------------- */
+/* Hierarchical Filter — Toolbar Button
+/* ----------------------------------------- */
+
+.filter-toolbar-btn {
+  display: flex;
+  align-items: center;
+  padding: 0px 1vw;
+  background-color: transparent;
+  font-weight: normal;
+  font-size: 16px;
+  cursor: pointer;
+  border-radius: 6px;
+  overflow: hidden;
+  height: 100%;
+  color: #8675a9;
+  font-family: Montserrat, sans-serif;
+  gap: 6px;
+}
+
+.filter-toolbar-btn:hover {
+  background-color: #c3aed6;
+  color: white;
+}
+
+.filter-toolbar-btn.active {
+  background-color: #8675a9;
+  color: white;
+}
+
+.filter-toolbar-btn-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* ----------------------------------------- */
+/* Hierarchical Filter — Editor Layout
+/* ----------------------------------------- */
+
+/*
+ * #editor-body-container becomes a flex row.
+ * #hot-container takes remaining space (flex: 1).
+ * .filter-sidebar sits on the right, width transitions from 0 to 280px.
+ */
+#editor-body-container {
+  display: flex;
+  flex-direction: row;
+}
+
+#hot-container {
+  flex: 1;
+  min-width: 0; /* allow shrinking below content width */
+}
+
+/* ----------------------------------------- */
+/* Hierarchical Filter — Sidebar
+/* ----------------------------------------- */
+
+.filter-sidebar {
+  width: 0;
+  overflow: hidden;
+  transition: width 250ms ease-out;
+  border-left: none;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 91vh;
+  background-color: #fff;
+  flex-shrink: 0;
+}
+
+.filter-sidebar.open {
+  width: 280px;
+  border-left: 1px solid #8675a9;
+}
+
+/* --- Header --- */
+
+.filter-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #e6e6e6;
+  flex-shrink: 0;
+  min-height: 40px;
+  box-sizing: border-box;
+}
+
+.filter-sidebar-title {
+  font-family: Montserrat, sans-serif;
+  font-weight: 700;
+  font-size: 13px;
+  color: #555;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.filter-sidebar-close {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background-color: #e6e6e6;
+  color: #888;
+  border: none;
+  font-size: 13px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-family: Montserrat, sans-serif;
+}
+
+.filter-sidebar-close:hover {
+  background-color: #c3aed6;
+  color: white;
+}
+
+/* --- Body --- */
+
+.filter-sidebar-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  box-sizing: border-box;
+}
+
+.filter-sidebar-placeholder {
+  color: #aaa;
+  font-family: Montserrat, sans-serif;
+  font-size: 13px;
+  text-align: center;
+  padding-top: 40px;
+}
+
+/* --- Footer --- */
+
+.filter-sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-top: 1px solid #e6e6e6;
+  flex-shrink: 0;
+  min-height: 44px;
+  box-sizing: border-box;
+  gap: 8px;
+}
+
+.filter-sidebar-btn {
+  font-family: Montserrat, sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 5px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: none;
+}
+
+.filter-sidebar-btn-clear {
+  background-color: #f2f2f2;
+  color: #666;
+}
+
+.filter-sidebar-btn-clear:hover {
+  background-color: #e6e6e6;
+  color: #333;
+}
+
+.filter-sidebar-btn-apply {
+  background-color: #8675a9;
+  color: white;
+}
+
+.filter-sidebar-btn-apply:hover {
+  background-color: #c3aed6;
+}

--- a/src/Editor/hierarchicalFilter/hierarchicalFilter.css
+++ b/src/Editor/hierarchicalFilter/hierarchicalFilter.css
@@ -178,3 +178,74 @@
 .filter-sidebar-btn-apply:hover {
   background-color: #c3aed6;
 }
+
+/* ----------------------------------------- */
+/* Hierarchical Filter — Tree UI
+/* ----------------------------------------- */
+
+.filter-tree {
+  font-family: Montserrat, sans-serif;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.filter-tree-row {
+  display: flex;
+  align-items: center;
+  padding: 3px 4px;
+  gap: 4px;
+  cursor: default;
+  border-radius: 3px;
+}
+
+.filter-tree-row:hover {
+  background-color: #f5f3f8;
+}
+
+.filter-tree-arrow {
+  width: 14px;
+  flex-shrink: 0;
+  text-align: center;
+  font-size: 12px;
+  color: #888;
+  user-select: none;
+}
+
+.filter-tree-arrow.clickable {
+  cursor: pointer;
+  color: #8675a9;
+}
+
+.filter-tree-arrow.clickable:hover {
+  color: #5a4a78;
+}
+
+.filter-tree-checkbox {
+  flex-shrink: 0;
+  margin: 0;
+  cursor: pointer;
+  accent-color: #8675a9;
+}
+
+.filter-tree-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #333;
+}
+
+.filter-tree-count {
+  flex-shrink: 0;
+  color: #999;
+  font-size: 11px;
+  margin-left: 2px;
+}
+
+.filter-tree-quality {
+  flex-shrink: 0;
+  font-size: 12px;
+  margin-left: 2px;
+  cursor: help;
+}

--- a/src/Editor/hierarchicalFilter/types.ts
+++ b/src/Editor/hierarchicalFilter/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Tree node for hierarchical classification filter.
+ *
+ * Classification strings are hierarchical (`neume.pes.quassus.flexus.23episema`).
+ * We split by `.` and build a tree where:
+ *   - Middle nodes = grouping containers (expand/collapse)
+ *   - Leaves = actual full strings that appear in the dataset
+ *
+ * A node can be BOTH a leaf AND have children ("self-node pattern"),
+ * e.g. `neume.pes.quassus` is itself a data row AND has descendants
+ * like `neume.pes.quassus.2episema`. In that case `isLeaf=true` and
+ * `children.size > 0`.
+ */
+export interface TreeNode {
+  /** Display label: trimmed, this-level token only. E.g. 'quassus'. */
+  label: string;
+
+  /** Full cleaned path from root. E.g. 'neume.pes.quassus'. */
+  fullPath: string;
+
+  /**
+   * Original raw string (may contain \n, trailing space, etc).
+   * Required by Handsontable's `by_value` filter — must match data exactly.
+   * Only set when isLeaf=true. null for pure grouping nodes.
+   */
+  rawValue: string | null;
+
+  /** True if this path is an actual entry in the source data. */
+  isLeaf: boolean;
+
+  /** Child nodes, keyed by next-level cleaned token. */
+  children: Map<string, TreeNode>;
+
+  /**
+   * Count of data rows reachable from this node (self + all descendants).
+   * Used to render "(30)" badges. Static — does not reflect other filters.
+   */
+  count: number;
+
+  /**
+   * Optional data quality flags. UI can show warning badges.
+   * Absent = clean. Only set on leaves.
+   */
+  quality?: {
+    hasNewline?: boolean;
+    hasEnDash?: boolean;
+    hasTrailingSpace?: boolean;
+  };
+}
+
+/**
+ * Sentinel label for rows where classification is empty/null/whitespace.
+ * Treated as a top-level bucket named "(uncategorized)".
+ */
+export const UNCATEGORIZED_KEY = '__uncategorized__';
+export const UNCATEGORIZED_LABEL = '(uncategorized)';


### PR DESCRIPTION
## Faceted Classification Filter

Adds a sidebar panel for filtering rows by classification hierarchy. This implements a **faceted search / faceted navigation** pattern for the classification column, allowing users to browse and filter by category/type/modifier using a tree UI, instead of scrolling through a flat list of full classification strings.

### Tree structure (Neume shape-small.docx example)

```
neume (20)
├── tractulus (2)
│   └── episema (1)
├── punctum (1)
├── gravis (1)
├── virga (2)
│   └── episema (1)
├── oriscus (3)
│   ├── curved (1)
│   ├── flat (1)
│   └── wave (1)
├── stropha (2)
│   └── episema (1)
└── pes (9)
    ├── rotundus (2)
    │   └── 2episema (1)
    ├── quadratus (2)
    │   └── 2episema (1)
    └── quassus (5)
        ├── 2episema (1)
        ├── flexus (2)
        │   └── 23episema (1)
        └── ...
```

### Features

- Toolbar "Filter" button (matches File/Help style) → right sidebar with tree UI
- Three-state checkboxes (all/some/none) with parent-child propagation
- Apply/Clear buttons driving Handsontable's `by_value` filter
- Resizable sidebar (drag left edge, 200–600px)
- Data quality warnings (⚠) for en-dash characters in classifications
- Also includes column sorting and custom dropdownMenu (removes built-in filter UI from column headers)

### Files added

```
src/Editor/hierarchicalFilter/
├── types.ts
├── classificationTreeParser.ts
├── FilterTree.ts
├── FilterSidebar.ts
└── hierarchicalFilter.css
```

### Testing

Tested with `Neume shape-small.docx` (20 rows) and `SQUAREnotation-NEUMElevel.csv` (39 rows, mixed categories). No console errors.


<img width="1245" height="744" alt="Screenshot 2026-04-28 at 23 59 21" src="https://github.com/user-attachments/assets/50fe1364-0c3d-40a6-b0e4-6a0a4a02b21d" />
