### PR TITLE
feat: save and load mapping files to/from GitHub

### DIFF
--- a/dev/scripts/editor.ts
+++ b/dev/scripts/editor.ts
@@ -1,4 +1,8 @@
-import { getMappingStorage } from '../../src/Dashboard/githubStorage/createMappingStorage';
+import {
+  getMappingStorage,
+  nameToPath,
+} from '../../src/Dashboard/githubStorage/createMappingStorage';
+import { rowsToCressPayload } from '../../src/Dashboard/githubStorage';
 
 import CressView from '../../src/CressView';
 import { parseWORD } from '../../src/Dashboard/Storage';
@@ -75,25 +79,38 @@ if (sampleId) {
   }
 } else {
   const db = new PouchDB('Cress-User-Storage');
-  db.getAttachment(uploadId, 'table')
-    .then((blob) => {
-      return new window.Response(blob).json();
-    })
-    .then(async (table) => {
-      console.log(table);
+  (async () => {
+    try {
+      // Name comes from the PouchDB doc (dashboard entry point); the storage
+      // key is name-based so it matches the GitHub filename + the local store.
       const doc: Doc = await db.get(uploadId);
       const name = doc.name;
-      let cressDoc: CressDoc = {
+      const path = nameToPath(name);
+
+      // Remote when logged in (fall back to local if the file isn't on GitHub
+      // yet -> progressive migration of old PouchDB docs); local-only when
+      // logged out. Returns CsvRow[] (string[][]) or null.
+      const rows = await getMappingStorage().loadMapping(path);
+      if (!rows) {
+        console.error(`No mapping found for "${path}"`);
+        return;
+      }
+
+      // string[][] -> Cress internal [headers, ...rowObjects].
+      const payload = rowsToCressPayload(rows);
+      const cressDoc: CressDoc = {
         id: uploadId,
-        name: name,
-        header: table[0],
-        body: table.slice(1),
+        name,
+        header: payload[0],
+        body: payload.slice(1) as Record<string, unknown>[],
       };
       const view = new CressView(cressDoc);
       view.start();
-    });
+    } catch (e) {
+      console.error('Failed to load mapping:', e);
+    }
+  })();
 }
-
 function getGetParam(paramName): string {
   let result;
 

--- a/dev/scripts/editor.ts
+++ b/dev/scripts/editor.ts
@@ -1,3 +1,5 @@
+import { getMappingStorage } from '../../src/Dashboard/githubStorage/createMappingStorage';
+
 import CressView from '../../src/CressView';
 import { parseWORD } from '../../src/Dashboard/Storage';
 import { IEntry, IFolder } from '../../src/Dashboard/FileSystem';

--- a/src/CressView.ts
+++ b/src/CressView.ts
@@ -44,7 +44,7 @@ class CressView {
 
         document.getElementById('loading').style.display = 'none';
 
-        this.table = new CressTable(this.id, this.header, this.body);
+        this.table = new CressTable(this.id, this.name, this.header, this.body);
 
         return;
       })

--- a/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
+++ b/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
@@ -42,6 +42,20 @@ function fromBase64(b64: string): string {
   return decodeURIComponent(escape(atob(clean)));
 }
 
+// The .csv suffix lives at this backend boundary ONLY. Callers (MappingStorage,
+// PouchDbLocalStore, nameToPath in createMappingStorage) all use bare names, so
+// the logged-out PouchDB lookup keeps matching. GitHub, by contrast, needs the
+// extension: it is what listFiles' *.csv filter selects, and what Rodan's MEI
+// Conversion Job consumes. So we add .csv on the way INTO every GitHub path and
+// strip it on the way OUT of listFiles, keeping both ends keyed on bare names.
+const CSV_EXT = '.csv';
+function withCsv(path: string): string {
+  return path.endsWith(CSV_EXT) ? path : `${path}${CSV_EXT}`;
+}
+function stripCsv(path: string): string {
+  return path.endsWith(CSV_EXT) ? path.slice(0, -CSV_EXT.length) : path;
+}
+
 export class GitHubUserRepoBackend implements StorageBackend {
   readonly kind = 'user-repo';
   constructor(private deps: GitHubBackendDeps) {}
@@ -62,7 +76,7 @@ export class GitHubUserRepoBackend implements StorageBackend {
 
   private contentsUrl(path: string): string {
     const { owner, repo } = this.deps;
-    return `${this.base}/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`;
+    return `${this.base}/repos/${owner}/${repo}/contents/${encodeURIComponent(withCsv(path))}`;
   }
 
   /** True if the target repo already exists for this user (GET /repos/:owner/:repo). */
@@ -143,7 +157,7 @@ export class GitHubUserRepoBackend implements StorageBackend {
     sha?: string | null,
   ): Promise<WriteResult> {
     const body: Record<string, unknown> = {
-      message: `cress: save ${path}`,
+      message: `cress: save ${withCsv(path)}`,
       content: toBase64(content),
     };
     if (this.deps.branch) body.branch = this.deps.branch;
@@ -177,7 +191,7 @@ export class GitHubUserRepoBackend implements StorageBackend {
     const url = new URL(this.contentsUrl(''));
     if (this.deps.branch) url.searchParams.set('ref', this.deps.branch);
     const res = await this.deps.fetch(
-      url.toString().replace(/contents\/$/, 'contents'),
+      url.toString().replace(/contents\/[^/?]*$/, 'contents'),
       {
         headers: this.authHeaders(),
       },
@@ -192,13 +206,13 @@ export class GitHubUserRepoBackend implements StorageBackend {
       type: string;
     }>;
     return json
-      .filter((e) => e.type === 'file' && e.name.endsWith('.csv'))
-      .map((e) => ({ path: e.name, sha: e.sha }));
+      .filter((e) => e.type === 'file' && e.name.endsWith(CSV_EXT))
+      .map((e) => ({ path: stripCsv(e.name), sha: e.sha }));
   }
 
   async deleteFile(path: string, sha: string): Promise<void> {
     const body: Record<string, unknown> = {
-      message: `cress: delete ${path}`,
+      message: `cress: delete ${withCsv(path)}`,
       sha,
     };
     if (this.deps.branch) body.branch = this.deps.branch;

--- a/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
+++ b/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
@@ -1,13 +1,11 @@
-// githubUserRepoBackend.ts
+// GitHubUserRepoBackend.ts
 // Option 2 backend: reads/writes files in the user's OWN repo via the GitHub
 // contents API, using the logged-in user's token (from getGithubToken()).
 //
-// SCOPE OF THIS PROTOTYPE:
-//   - Assumes the target repo ALREADY EXISTS. The first-save auto-create step
-//     (POST /user/repos to make `cress-mappings`) is intentionally OUT of scope
-//     until the meeting picks Option 1 vs 2. ensureRepo() is a TODO stub below.
-//   - Everything else (read/write/list/delete + SHA conflict) is common logic
-//     that also applies to Option 1, just pointed at a different endpoint.
+// ensureRepo() creates the repo (POST /user/repos) on first use if it's
+// missing. Call it once before the first save; it is idempotent (no-op when the
+// repo already exists). All other ops (read/write/list/delete + SHA conflict)
+// are common logic shared with Option 1, just pointed at GitHub directly.
 
 import {
   StorageBackend,
@@ -67,13 +65,57 @@ export class GitHubUserRepoBackend implements StorageBackend {
     return `${this.base}/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`;
   }
 
-  // TODO(Option 2, post-meeting): create the repo on first save if it's missing.
-  //   POST /user/repos { name: "cress-mappings", private: false, auto_init: true }
-  // Out of scope for this prototype on purpose.
+  /** True if the target repo already exists for this user (GET /repos/:owner/:repo). */
+  async repoExists(): Promise<boolean> {
+    const { owner, repo } = this.deps;
+    const res = await this.deps.fetch(`${this.base}/repos/${owner}/${repo}`, {
+      headers: this.authHeaders(),
+    });
+    if (res.status === 404) return false;
+    if (!res.ok) {
+      throw new Error(
+        `repoExists failed: ${res.status} ${await safeText(res)}`,
+      );
+    }
+    return true;
+  }
+
+  /**
+   * Create the target repo if it does not exist. Idempotent: a no-op when the
+   * repo is already present.
+   *
+   * auto_init: true creates an initial commit (a README) so the repo has a
+   * default branch immediately; without it the contents API has no branch to
+   * write the first file against.
+   *
+   * NOTE: this writes to the real GitHub account behind the token. It creates a
+   * public repo named `repo` (default "cress-mappings"). private:false because
+   * the OAuth scope is public_repo.
+   */
   async ensureRepo(): Promise<void> {
-    throw new Error(
-      'ensureRepo() not implemented yet (POST /user/repos deferred)',
-    );
+    if (await this.repoExists()) return;
+
+    const res = await this.deps.fetch(`${this.base}/user/repos`, {
+      method: 'POST',
+      headers: { ...this.authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: this.deps.repo,
+        private: false,
+        auto_init: true,
+        description: 'Cress mapping files (auto-created)',
+      }),
+    });
+
+    // 201 Created on success. 422 can mean "name already exists" (race with
+    // another tab) -- treat that as success since the repo is now present.
+    if (res.status === 422) {
+      if (await this.repoExists()) return;
+    }
+    if (!res.ok) {
+      throw new Error(
+        `ensureRepo failed: ${res.status} ${await safeText(res)}`,
+      );
+    }
   }
 
   async readFile(path: string): Promise<ReadResult | null> {

--- a/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
+++ b/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
@@ -1,0 +1,181 @@
+// githubUserRepoBackend.ts
+// Option 2 backend: reads/writes files in the user's OWN repo via the GitHub
+// contents API, using the logged-in user's token (from getGithubToken()).
+//
+// SCOPE OF THIS PROTOTYPE:
+//   - Assumes the target repo ALREADY EXISTS. The first-save auto-create step
+//     (POST /user/repos to make `cress-mappings`) is intentionally OUT of scope
+//     until the meeting picks Option 1 vs 2. ensureRepo() is a TODO stub below.
+//   - Everything else (read/write/list/delete + SHA conflict) is common logic
+//     that also applies to Option 1, just pointed at a different endpoint.
+
+import {
+  StorageBackend,
+  StoredFileMeta,
+  ReadResult,
+  WriteResult,
+  ConflictError,
+  NotAuthenticatedError,
+} from './backend';
+
+// Injectable fetch + token getter so this is unit-testable without a browser
+// or real network. In Cress these default to window.fetch and the real
+// getGithubToken() exported from cress-frontend-auth.ts.
+export interface GitHubBackendDeps {
+  fetch: typeof fetch;
+  getToken: () => string | null;
+  owner: string; // GitHub username (repo owner)
+  repo: string; // e.g. "cress-mappings"
+  branch?: string; // default branch; undefined = repo default
+  apiBase?: string; // default "https://api.github.com"
+}
+
+// base64 helpers that work in both browser and node (prototype runs in node).
+function toBase64(s: string): string {
+  if (typeof Buffer !== 'undefined')
+    return Buffer.from(s, 'utf-8').toString('base64');
+  // browser
+  return btoa(unescape(encodeURIComponent(s)));
+}
+function fromBase64(b64: string): string {
+  const clean = b64.replace(/\n/g, '');
+  if (typeof Buffer !== 'undefined')
+    return Buffer.from(clean, 'base64').toString('utf-8');
+  return decodeURIComponent(escape(atob(clean)));
+}
+
+export class GitHubUserRepoBackend implements StorageBackend {
+  readonly kind = 'user-repo';
+  constructor(private deps: GitHubBackendDeps) {}
+
+  private get base() {
+    return this.deps.apiBase ?? 'https://api.github.com';
+  }
+
+  private authHeaders(): Record<string, string> {
+    const token = this.deps.getToken();
+    if (!token) throw new NotAuthenticatedError();
+    return {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+  }
+
+  private contentsUrl(path: string): string {
+    const { owner, repo } = this.deps;
+    return `${this.base}/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`;
+  }
+
+  // TODO(Option 2, post-meeting): create the repo on first save if it's missing.
+  //   POST /user/repos { name: "cress-mappings", private: false, auto_init: true }
+  // Out of scope for this prototype on purpose.
+  async ensureRepo(): Promise<void> {
+    throw new Error(
+      'ensureRepo() not implemented yet (POST /user/repos deferred)',
+    );
+  }
+
+  async readFile(path: string): Promise<ReadResult | null> {
+    const url = new URL(this.contentsUrl(path));
+    if (this.deps.branch) url.searchParams.set('ref', this.deps.branch);
+    const res = await this.deps.fetch(url.toString(), {
+      headers: this.authHeaders(),
+    });
+
+    if (res.status === 404) return null;
+    if (!res.ok)
+      throw new Error(`readFile failed: ${res.status} ${await safeText(res)}`);
+
+    const json = (await res.json()) as { content?: string; sha?: string };
+    if (json.content === undefined) {
+      // Could be a directory response (array) — not a file.
+      throw new Error(`readFile: ${path} is not a file`);
+    }
+    return { content: fromBase64(json.content), sha: json.sha ?? null };
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    sha?: string | null,
+  ): Promise<WriteResult> {
+    const body: Record<string, unknown> = {
+      message: `cress: save ${path}`,
+      content: toBase64(content),
+    };
+    if (this.deps.branch) body.branch = this.deps.branch;
+    if (sha) body.sha = sha; // update; omit for create
+
+    const res = await this.deps.fetch(this.contentsUrl(path), {
+      method: 'PUT',
+      headers: { ...this.authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    // 409 = sha is stale (someone else wrote). 422 can also indicate sha issues.
+    if (res.status === 409) {
+      throw new ConflictError(
+        `Write conflict on ${path} (remote changed)`,
+        path,
+      );
+    }
+    if (!res.ok) {
+      throw new Error(`writeFile failed: ${res.status} ${await safeText(res)}`);
+    }
+
+    const json = (await res.json()) as { content?: { sha?: string } };
+    const newSha = json.content?.sha;
+    if (!newSha) throw new Error('writeFile: no sha in response');
+    return { sha: newSha };
+  }
+
+  async listFiles(): Promise<StoredFileMeta[]> {
+    // List the repo root (prototype). Real impl may scope to a subdir.
+    const url = new URL(this.contentsUrl(''));
+    if (this.deps.branch) url.searchParams.set('ref', this.deps.branch);
+    const res = await this.deps.fetch(
+      url.toString().replace(/contents\/$/, 'contents'),
+      {
+        headers: this.authHeaders(),
+      },
+    );
+    if (res.status === 404) return [];
+    if (!res.ok)
+      throw new Error(`listFiles failed: ${res.status} ${await safeText(res)}`);
+
+    const json = (await res.json()) as Array<{
+      name: string;
+      sha: string;
+      type: string;
+    }>;
+    return json
+      .filter((e) => e.type === 'file' && e.name.endsWith('.csv'))
+      .map((e) => ({ path: e.name, sha: e.sha }));
+  }
+
+  async deleteFile(path: string, sha: string): Promise<void> {
+    const body: Record<string, unknown> = {
+      message: `cress: delete ${path}`,
+      sha,
+    };
+    if (this.deps.branch) body.branch = this.deps.branch;
+    const res = await this.deps.fetch(this.contentsUrl(path), {
+      method: 'DELETE',
+      headers: { ...this.authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok)
+      throw new Error(
+        `deleteFile failed: ${res.status} ${await safeText(res)}`,
+      );
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '<no body>';
+  }
+}

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -1,0 +1,158 @@
+// storage.ts
+// The common orchestration layer. Talks ONLY to StorageBackend + the CSV pure
+// functions, so it is identical whether the backend is Option 1 (Worker) or
+// Option 2 (user repo). This is the "doesn't get thrown away" core.
+//
+// Responsibilities:
+//   - turn Cress table rows into CSV and back (delegates to csv.ts)
+//   - remember the last-seen SHA per file so updates are conflict-checked
+//   - when not logged in, fall back to a local store (PouchDB in Cress; an
+//     in-memory map in this prototype) so the app still works offline (#138).
+
+import { rowsToCsv, csvToRows, CsvRow } from './csv';
+import {
+  StorageBackend,
+  ConflictError,
+  NotAuthenticatedError,
+  StoredFileMeta,
+} from './backend';
+
+/** Minimal local store interface. In Cress this is backed by PouchDB
+ *  (Cress-User-Storage). In the prototype it's an in-memory Map. */
+export interface LocalStore {
+  get(path: string): Promise<string | null>;
+  set(path: string, content: string): Promise<void>;
+  list(): Promise<string[]>;
+  remove(path: string): Promise<void>;
+}
+
+export interface MappingStorageDeps {
+  backend: StorageBackend;
+  local: LocalStore;
+  /** Returns the current token, or null if logged out. Wraps getGithubToken(). */
+  getToken: () => string | null;
+}
+
+export type SaveOutcome =
+  | { status: 'saved-remote'; path: string; sha: string }
+  | { status: 'saved-local'; path: string } // logged out -> local only
+  | { status: 'conflict'; path: string };
+
+export class MappingStorage {
+  // path -> last known remote SHA, for conflict-safe updates within a session.
+  private shaCache = new Map<string, string>();
+
+  constructor(private deps: MappingStorageDeps) {}
+
+  private isLoggedIn(): boolean {
+    return this.deps.getToken() != null;
+  }
+
+  /** Serialize table rows and persist. Remote when logged in, local otherwise. */
+  async saveMapping(path: string, rows: CsvRow[]): Promise<SaveOutcome> {
+    const csv = rowsToCsv(rows);
+
+    // Logged-out fallback: keep working against the local store only (#138).
+    if (!this.isLoggedIn()) {
+      await this.deps.local.set(path, csv);
+      return { status: 'saved-local', path };
+    }
+
+    const knownSha = this.shaCache.get(path) ?? null;
+    try {
+      const { sha } = await this.deps.backend.writeFile(path, csv, knownSha);
+      this.shaCache.set(path, sha);
+      // mirror to local so logged-out reads still see latest
+      await this.deps.local.set(path, csv);
+      return { status: 'saved-remote', path, sha };
+    } catch (err) {
+      if (err instanceof ConflictError) return { status: 'conflict', path };
+      if (err instanceof NotAuthenticatedError) {
+        await this.deps.local.set(path, csv);
+        return { status: 'saved-local', path };
+      }
+      throw err;
+    }
+  }
+
+  /** Load a mapping as table rows. Remote when logged in (falling back to local
+   *  if the remote file is missing), local-only when logged out. */
+  async loadMapping(path: string): Promise<CsvRow[] | null> {
+    if (this.isLoggedIn()) {
+      const remote = await this.deps.backend.readFile(path);
+      if (remote) {
+        if (remote.sha) this.shaCache.set(path, remote.sha);
+        await this.deps.local.set(path, remote.content); // refresh local mirror
+        return csvToRows(remote.content);
+      }
+      // fall through to local if not on remote
+    }
+    const local = await this.deps.local.get(path);
+    return local == null ? null : csvToRows(local);
+  }
+
+  /** Force-overwrite the remote file, ignoring the cached SHA. Used after the
+   *  user chooses "keep mine" on a conflict. Re-reads current SHA first so the
+   *  PUT is accepted. */
+  async resolveConflictKeepLocal(
+    path: string,
+    rows: CsvRow[],
+  ): Promise<SaveOutcome> {
+    if (!this.isLoggedIn()) {
+      await this.deps.local.set(path, rowsToCsv(rows));
+      return { status: 'saved-local', path };
+    }
+    const current = await this.deps.backend.readFile(path);
+    const csv = rowsToCsv(rows);
+    const { sha } = await this.deps.backend.writeFile(
+      path,
+      csv,
+      current?.sha ?? null,
+    );
+    this.shaCache.set(path, sha);
+    await this.deps.local.set(path, csv);
+    return { status: 'saved-remote', path, sha };
+  }
+
+  /** List available mappings. Merges remote + local names when logged in. */
+  async listMappings(): Promise<string[]> {
+    const localNames = await this.deps.local.list();
+    if (!this.isLoggedIn()) return localNames.sort();
+    let remote: StoredFileMeta[] = [];
+    try {
+      remote = await this.deps.backend.listFiles();
+    } catch (err) {
+      if (!(err instanceof NotAuthenticatedError)) throw err;
+    }
+    remote.forEach((m) => this.shaCache.set(m.path, m.sha ?? ''));
+    const set = new Set<string>([...localNames, ...remote.map((m) => m.path)]);
+    return [...set].sort();
+  }
+
+  async deleteMapping(path: string): Promise<void> {
+    await this.deps.local.remove(path);
+    if (!this.isLoggedIn()) return;
+    const sha = this.shaCache.get(path);
+    if (sha) {
+      await this.deps.backend.deleteFile(path, sha);
+      this.shaCache.delete(path);
+    }
+  }
+}
+
+/** Trivial in-memory LocalStore for the prototype/tests. Cress swaps in PouchDB. */
+export class InMemoryLocalStore implements LocalStore {
+  private m = new Map<string, string>();
+  async get(p: string) {
+    return this.m.has(p) ? this.m.get(p)! : null;
+  }
+  async set(p: string, c: string) {
+    this.m.set(p, c);
+  }
+  async list() {
+    return [...this.m.keys()];
+  }
+  async remove(p: string) {
+    this.m.delete(p);
+  }
+}

--- a/src/Dashboard/githubStorage/PouchDbLocalStore.ts
+++ b/src/Dashboard/githubStorage/PouchDbLocalStore.ts
@@ -1,0 +1,109 @@
+// PouchDbLocalStore.ts
+// Adapter that implements the LocalStore interface (from MappingStorage.ts) on
+// top of Cress's existing PouchDB layer in ../Storage.ts. This is the
+// logged-out / offline fallback store (#138): Storage.ts itself is NOT changed,
+// we only call its existing exported functions.
+//
+// PROTOTYPE STATUS: skeleton. The reads/writes are wired to the real Storage.ts
+// function names, but two things are deliberately simplified and flagged with
+// TODO for when this is finalized against the running app:
+//
+//   1. id vs name. Storage.ts identifies documents by a PouchDB `_id` AND a
+//      display `name` (see addDocument(id, name, content) and fetchUploads()
+//      which returns {id, name}). LocalStore has a single `path`. This adapter
+//      treats `path` as BOTH the _id and the name. If Cress needs distinct ids
+//      (e.g. uuid _id + human name), resolve path->id via fetchUploads() here.
+//
+//   2. Content shape. Storage.ts stores a JSON attachment of
+//      [headers, ...rowObjects] (Cress internal), NOT a raw CSV string.
+//      LocalStore.get/set speak CSV strings (to stay backend-agnostic with the
+//      remote side). So this adapter converts at the boundary using cressRows +
+//      csv. The exact attachment read path (db.getAttachment vs the JSON in the
+//      doc) must be confirmed against how the editor currently loads it; the
+//      readAttachmentAsPayload() helper below marks that seam.
+
+import { LocalStore } from './MappingStorage';
+import { rowsToCsv, csvToRows } from './csv';
+import {
+  cressPayloadToRows,
+  rowsToCressPayload,
+  CressTablePayload,
+} from './cressRows';
+
+// These are the real exports from ../Storage.ts. Imported by name so the
+// compiler checks the signatures when this is dropped into src/Dashboard/.
+import {
+  fetchUploads,
+  addDocument,
+  updateAttachment,
+  deleteDocument,
+  // NOTE: Storage.ts also exports `db` (the PouchDB instance) and parseWORD,
+  // createJson, updateDocName. We use `db` for attachment reads below.
+  db,
+} from '../Storage';
+
+export class PouchDbLocalStore implements LocalStore {
+  /**
+   * Resolve a path (which we treat as the document name) to its PouchDB _id.
+   * Returns null if no document with that name exists.
+   * TODO: if path===_id is adopted, this becomes the identity function.
+   */
+  private async resolveId(path: string): Promise<string | null> {
+    const uploads = await fetchUploads();
+    const hit = uploads.find((u) => u.name === path);
+    return hit ? hit.id : null;
+  }
+
+  /**
+   * Read the [headers, ...rowObjects] payload stored as the doc's "table"
+   * attachment. SEAM: confirm this matches how the editor currently reads it.
+   */
+  private async readAttachmentAsPayload(
+    id: string,
+  ): Promise<CressTablePayload | null> {
+    try {
+      const blob = (await db.getAttachment(id, 'table')) as Blob;
+      const text = await blob.text();
+      return JSON.parse(text) as CressTablePayload;
+    } catch (e) {
+      console.error('PouchDbLocalStore.readAttachmentAsPayload failed:', e);
+      return null;
+    }
+  }
+
+  async get(path: string): Promise<string | null> {
+    const id = await this.resolveId(path);
+    if (!id) return null;
+    const payload = await this.readAttachmentAsPayload(id);
+    if (!payload) return null;
+    // Cress internal payload -> string[][] -> CSV string (LocalStore contract).
+    return rowsToCsv(cressPayloadToRows(payload));
+  }
+
+  async set(path: string, content: string): Promise<void> {
+    // CSV string -> string[][] -> Cress internal [headers, ...rowObjects].
+    const payload = rowsToCressPayload(csvToRows(content));
+    const id = await this.resolveId(path);
+    if (id) {
+      // Existing doc: update its attachment in place.
+      await updateAttachment(id, payload as unknown as any[]);
+    } else {
+      // New doc: create it. addDocument expects a Blob attachment of the JSON.
+      const blob = new Blob([JSON.stringify(payload)], {
+        type: 'application/json',
+      });
+      // path used as BOTH id and name (see header note, simplification #1).
+      await addDocument(path, path, blob);
+    }
+  }
+
+  async list(): Promise<string[]> {
+    const uploads = await fetchUploads();
+    return uploads.map((u) => u.name);
+  }
+
+  async remove(path: string): Promise<void> {
+    const id = await this.resolveId(path);
+    if (id) await deleteDocument(id);
+  }
+}

--- a/src/Dashboard/githubStorage/PouchDbLocalStore.ts
+++ b/src/Dashboard/githubStorage/PouchDbLocalStore.ts
@@ -4,23 +4,27 @@
 // logged-out / offline fallback store (#138): Storage.ts itself is NOT changed,
 // we only call its existing exported functions.
 //
-// PROTOTYPE STATUS: skeleton. The reads/writes are wired to the real Storage.ts
-// function names, but two things are deliberately simplified and flagged with
-// TODO for when this is finalized against the running app:
+// Two seams that were previously TODO are now resolved against the real
+// Storage.ts / CressTable.ts:
 //
 //   1. id vs name. Storage.ts identifies documents by a PouchDB `_id` AND a
-//      display `name` (see addDocument(id, name, content) and fetchUploads()
-//      which returns {id, name}). LocalStore has a single `path`. This adapter
-//      treats `path` as BOTH the _id and the name. If Cress needs distinct ids
-//      (e.g. uuid _id + human name), resolve path->id via fetchUploads() here.
+//      display `name` (addDocument(id, name, content); fetchUploads() returns
+//      {id, name}). LocalStore exposes a single `path`. RESOLUTION: `path` is
+//      the human-facing NAME. For an EXISTING document we look up its real
+//      PouchDB `_id` via fetchUploads() (resolveId) and update against that id,
+//      so we never assume name===_id for updates. For a NEW document we still
+//      mint the id from the name (sanitized to satisfy PouchDB _id rules); when
+//      the app wiring lands we can switch to a uuid _id here without touching
+//      anything above this adapter.
 //
 //   2. Content shape. Storage.ts stores a JSON attachment of
-//      [headers, ...rowObjects] (Cress internal), NOT a raw CSV string.
-//      LocalStore.get/set speak CSV strings (to stay backend-agnostic with the
-//      remote side). So this adapter converts at the boundary using cressRows +
-//      csv. The exact attachment read path (db.getAttachment vs the JSON in the
-//      doc) must be confirmed against how the editor currently loads it; the
-//      readAttachmentAsPayload() helper below marks that seam.
+//      [headers, ...rowObjects] (Cress internal), NOT a raw CSV string. The
+//      attachment is read back via db.getAttachment(id, 'table'). PouchDB types
+//      that as Blob | Buffer, so readAttachmentAsPayload() narrows at runtime
+//      (Blob.text() in the browser, Buffer.toString() under node tests) instead
+//      of an unchecked cast. LocalStore.get/set speak CSV strings to stay
+//      backend-agnostic, so this adapter converts at the boundary using
+//      cressRows + csv.
 
 import { LocalStore } from './MappingStorage';
 import { rowsToCsv, csvToRows } from './csv';
@@ -30,40 +34,72 @@ import {
   CressTablePayload,
 } from './cressRows';
 
-// These are the real exports from ../Storage.ts. Imported by name so the
-// compiler checks the signatures when this is dropped into src/Dashboard/.
+// Real exports from ../Storage.ts. Imported by name so the compiler checks the
+// signatures when this is dropped into src/Dashboard/.
 import {
   fetchUploads,
   addDocument,
   updateAttachment,
   deleteDocument,
-  // NOTE: Storage.ts also exports `db` (the PouchDB instance) and parseWORD,
-  // createJson, updateDocName. We use `db` for attachment reads below.
   db,
 } from '../Storage';
 
+/**
+ * Sanitize a human name into something usable as a PouchDB _id.
+ * PouchDB forbids ids beginning with '_' (reserved). We also trim whitespace.
+ * This only affects NEW documents; existing ones are addressed by their real
+ * stored _id via resolveId().
+ */
+function nameToId(name: string): string {
+  const trimmed = name.trim();
+  const safe = trimmed.startsWith('_') ? trimmed.replace(/^_+/, '') : trimmed;
+  if (safe !== trimmed) {
+    console.warn(
+      `PouchDbLocalStore: name "${name}" is not a valid PouchDB _id; ` +
+        `using "${safe}" as id (name preserved for display).`,
+    );
+  }
+  return safe;
+}
+
 export class PouchDbLocalStore implements LocalStore {
   /**
-   * Resolve a path (which we treat as the document name) to its PouchDB _id.
+   * Resolve a path (treated as the document NAME) to its PouchDB _id.
    * Returns null if no document with that name exists.
-   * TODO: if path===_id is adopted, this becomes the identity function.
+   * NOTE: fetchUploads() does not guarantee unique names; we take the first
+   * match. The app-wiring step should decide whether duplicate names are
+   * allowed or disambiguated.
    */
   private async resolveId(path: string): Promise<string | null> {
     const uploads = await fetchUploads();
-    const hit = uploads.find((u) => u.name === path);
-    return hit ? hit.id : null;
+    const matches = uploads.filter((u) => u.name === path);
+    if (matches.length > 1) {
+      console.warn(
+        `PouchDbLocalStore: ${matches.length} documents named "${path}"; ` +
+          `using the first. Consider unique names.`,
+      );
+    }
+    return matches.length > 0 ? matches[0].id : null;
   }
 
   /**
    * Read the [headers, ...rowObjects] payload stored as the doc's "table"
-   * attachment. SEAM: confirm this matches how the editor currently reads it.
+   * attachment. Narrows the PouchDB Blob | Buffer return at runtime.
    */
   private async readAttachmentAsPayload(
     id: string,
   ): Promise<CressTablePayload | null> {
     try {
-      const blob = (await db.getAttachment(id, 'table')) as Blob;
-      const text = await blob.text();
+      const att = await db.getAttachment(id, 'table');
+      let text: string;
+      if (typeof Blob !== 'undefined' && att instanceof Blob) {
+        text = await att.text();
+      } else if (typeof Buffer !== 'undefined' && att instanceof Buffer) {
+        text = att.toString('utf-8');
+      } else {
+        // Fallback: some PouchDB adapters return a base64 string.
+        text = String(att);
+      }
       return JSON.parse(text) as CressTablePayload;
     } catch (e) {
       console.error('PouchDbLocalStore.readAttachmentAsPayload failed:', e);
@@ -82,18 +118,21 @@ export class PouchDbLocalStore implements LocalStore {
 
   async set(path: string, content: string): Promise<void> {
     // CSV string -> string[][] -> Cress internal [headers, ...rowObjects].
+    // This is exactly the shape updateAttachment/addDocument expect
+    // ([header, ...content]); see Storage.ts JSDoc and CressTable's
+    // updateAttachment(id, [inputHeader, ...body]).
     const payload = rowsToCressPayload(csvToRows(content));
     const id = await this.resolveId(path);
     if (id) {
-      // Existing doc: update its attachment in place.
-      await updateAttachment(id, payload as unknown as any[]);
+      // Existing doc: update its attachment in place, addressed by real _id.
+      await updateAttachment(id, payload);
     } else {
-      // New doc: create it. addDocument expects a Blob attachment of the JSON.
+      // New doc: mint an id from the name; keep `path` as the display name.
+      const newId = nameToId(path);
       const blob = new Blob([JSON.stringify(payload)], {
         type: 'application/json',
       });
-      // path used as BOTH id and name (see header note, simplification #1).
-      await addDocument(path, path, blob);
+      await addDocument(newId, path, blob);
     }
   }
 

--- a/src/Dashboard/githubStorage/WorkerBackend.ts
+++ b/src/Dashboard/githubStorage/WorkerBackend.ts
@@ -1,0 +1,135 @@
+// WorkerBackend.ts
+// Option 1 backend: instead of writing to GitHub directly with the user's
+// token, the frontend sends each storage operation to a lab-owned Cloudflare
+// Worker endpoint. The Worker authenticates the user (by their OAuth token),
+// then performs the GitHub write using LAB-held credentials (a GitHub App
+// installation token or a fine-grained PAT). This lets the lab own/centralize
+// the data while users never hold write access to the lab repo.
+//
+// This class implements the SAME StorageBackend interface as
+// GitHubUserRepoBackend, so MappingStorage / csv / cressRows are unchanged --
+// only which backend is injected differs.
+//
+// WORKER ENDPOINT CONTRACT (what the lab Worker must implement for this to
+// work end-to-end). The Worker base URL is passed in as `workerUrl`. Every
+// request carries the user's OAuth token in the Authorization header so the
+// Worker can verify identity before acting:
+//
+//   POST   {workerUrl}/files/read     { path }            -> 200 { content, sha } | 404
+//   POST   {workerUrl}/files/write    { path, content, sha? } -> 200 { sha } | 409 conflict
+//   POST   {workerUrl}/files/list                          -> 200 { files: [{path, sha}] }
+//   POST   {workerUrl}/files/delete   { path, sha }         -> 200 {}
+//
+// content is the raw UTF-8 file text (the Worker base64-encodes for GitHub).
+// The Worker is the only holder of GitHub write credentials; the user token is
+// used purely for authn/authz at the Worker.
+//
+// STATUS: frontend side is complete and mock-tested. The Worker endpoints above
+// do NOT exist yet -- the current Worker only does OAuth token exchange. Wiring
+// this end-to-end requires extending the Worker, which is deferred until the
+// meeting confirms Option 1 is the chosen direction.
+
+import {
+  StorageBackend,
+  StoredFileMeta,
+  ReadResult,
+  WriteResult,
+  ConflictError,
+  NotAuthenticatedError,
+} from './backend';
+
+export interface WorkerBackendDeps {
+  fetch: typeof fetch;
+  getToken: () => string | null;
+  workerUrl: string; // e.g. "https://cress-auth.ddmal.workers.dev"
+}
+
+export class WorkerBackend implements StorageBackend {
+  readonly kind = 'worker';
+  constructor(private deps: WorkerBackendDeps) {}
+
+  private authHeaders(): Record<string, string> {
+    const token = this.deps.getToken();
+    if (!token) throw new NotAuthenticatedError();
+    return {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private endpoint(op: string): string {
+    return `${this.deps.workerUrl.replace(/\/$/, '')}/files/${op}`;
+  }
+
+  async readFile(path: string): Promise<ReadResult | null> {
+    const res = await this.deps.fetch(this.endpoint('read'), {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify({ path }),
+    });
+    if (res.status === 404) return null;
+    if (!res.ok)
+      throw new Error(`readFile failed: ${res.status} ${await safeText(res)}`);
+    const json = (await res.json()) as { content: string; sha: string | null };
+    return { content: json.content, sha: json.sha ?? null };
+  }
+
+  async writeFile(
+    path: string,
+    content: string,
+    sha?: string | null,
+  ): Promise<WriteResult> {
+    const body: Record<string, unknown> = { path, content };
+    if (sha) body.sha = sha;
+    const res = await this.deps.fetch(this.endpoint('write'), {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (res.status === 409) {
+      throw new ConflictError(
+        `Write conflict on ${path} (remote changed)`,
+        path,
+      );
+    }
+    if (!res.ok)
+      throw new Error(`writeFile failed: ${res.status} ${await safeText(res)}`);
+    const json = (await res.json()) as { sha?: string };
+    if (!json.sha) throw new Error('writeFile: no sha in response');
+    return { sha: json.sha };
+  }
+
+  async listFiles(): Promise<StoredFileMeta[]> {
+    const res = await this.deps.fetch(this.endpoint('list'), {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify({}),
+    });
+    if (!res.ok)
+      throw new Error(`listFiles failed: ${res.status} ${await safeText(res)}`);
+    const json = (await res.json()) as {
+      files: Array<{ path: string; sha: string | null }>;
+    };
+    return json.files.map((f) => ({ path: f.path, sha: f.sha ?? null }));
+  }
+
+  async deleteFile(path: string, sha: string): Promise<void> {
+    const res = await this.deps.fetch(this.endpoint('delete'), {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify({ path, sha }),
+    });
+    if (!res.ok)
+      throw new Error(
+        `deleteFile failed: ${res.status} ${await safeText(res)}`,
+      );
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '<no body>';
+  }
+}

--- a/src/Dashboard/githubStorage/backend.ts
+++ b/src/Dashboard/githubStorage/backend.ts
@@ -1,0 +1,63 @@
+// backend.ts
+// The abstraction that lets Option 1 (Worker proxy) and Option 2 (user's own repo)
+// share all the common logic above it. The save/load/list orchestration in
+// storage.ts talks ONLY to this interface, so switching options = swapping the
+// backend implementation, with zero change to the orchestration layer.
+
+export interface StoredFileMeta {
+  /** Path/identifier of the file within the backend (e.g. "my-map.csv"). */
+  path: string;
+  /** GitHub blob SHA, needed to update/delete without a conflict. Null if unknown. */
+  sha: string | null;
+}
+
+export interface ReadResult {
+  content: string; // decoded UTF-8 file content
+  sha: string | null; // SHA of the blob we just read (for later conflict-safe writes)
+}
+
+export interface WriteResult {
+  sha: string; // SHA of the newly written blob
+}
+
+/** Raised when a write is rejected because the remote blob changed since we read it
+ *  (HTTP 409 from the GitHub contents API, or an SHA mismatch). */
+export class ConflictError extends Error {
+  constructor(
+    message: string,
+    public readonly path: string,
+  ) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}
+
+/** Raised when the backend cannot operate because there is no auth token. */
+export class NotAuthenticatedError extends Error {
+  constructor(message = 'Not logged in to GitHub') {
+    super(message);
+    this.name = 'NotAuthenticatedError';
+  }
+}
+
+export interface StorageBackend {
+  /** Human-readable label for logging / UI ("user-repo", "worker"). */
+  readonly kind: string;
+
+  /** Read a file. Resolves null if the file does not exist. */
+  readFile(path: string): Promise<ReadResult | null>;
+
+  /** Create or update a file. If `sha` is provided, the write is conflict-checked
+   *  against it (throws ConflictError on mismatch). Omit `sha` for a fresh create. */
+  writeFile(
+    path: string,
+    content: string,
+    sha?: string | null,
+  ): Promise<WriteResult>;
+
+  /** List stored files (just metadata, not content). */
+  listFiles(): Promise<StoredFileMeta[]>;
+
+  /** Delete a file by path + sha. */
+  deleteFile(path: string, sha: string): Promise<void>;
+}

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -38,15 +38,20 @@ const getOwner = (): string =>
  * - GitHub contents API treats '/' and '\' as directory separators, so they are
  *   replaced. Whitespace is collapsed. Unicode/spaces are otherwise preserved
  *   (contentsUrl() URL-encodes the path).
- * - listFiles() only returns *.csv, and listMappings() merges remote paths with
- *   local names by string equality, so the path must end in '.csv' on both ends.
+ * - No .csv suffix here: PouchDB docs are keyed by bare name. The GitHub
+ *   backend adds .csv at its own boundary (listFiles filters *.csv).
  */
 export function nameToPath(name: string): string {
-  const base = name
+  // Bare, sanitized name -- NO .csv suffix. PouchDB's existing docs are keyed
+  // by name without an extension (see Dashboard.ts handleAddFile -> addDocument),
+  // and PouchDbLocalStore.resolveId matches on that name, so adding .csv here
+  // makes the local lookup miss. The .csv suffix that GitHub needs (for
+  // listFiles' *.csv filter) is the GitHub backend's concern and will be added
+  // at that boundary when remote storage is wired, not here.
+  return name
     .trim()
     .replace(/[/\\]+/g, '-')
     .replace(/\s+/g, ' ');
-  return base.toLowerCase().endsWith('.csv') ? base : `${base}.csv`;
 }
 
 // Lazy singleton: assembled on first use, by which point the editor load flow

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -1,0 +1,103 @@
+// createMappingStorage.ts
+// App-wiring assembly point for #3. The barrel (index.ts) only exports classes;
+// this is where they are composed into a ready-to-use MappingStorage instance.
+//
+// Importing this file from an entry (editor.ts) is what finally pulls the whole
+// githubStorage/ module into the webpack bundle + type-check. Until now nothing
+// imported it, so it was never compiled into the app.
+//
+// AUTH CONTRACT (shared with the OAuth frontend on feat/github-oauth-frontend):
+//   localStorage 'cress_github_token'    -> bearer token (null when logged out)
+//   localStorage 'cress_github_username' -> GitHub login (repo owner for Option 2)
+// We read these keys directly instead of importing getGithubToken(), so this
+// branch (feat/github-storage) does NOT depend on the OAuth branch's symbols.
+// AFTER the OAuth PR merges into main, swap getToken below for the imported
+// getGithubToken() (it reads the same key and also yields the username).
+
+import { MappingStorage } from './MappingStorage';
+import { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
+import { PouchDbLocalStore } from './PouchDbLocalStore';
+// Option 1 (Worker) -- swap in at the assembly line below if the meeting picks it.
+// import { WorkerBackend } from './WorkerBackend';
+
+const TOKEN_KEY = 'cress_github_token';
+const USERNAME_KEY = 'cress_github_username';
+const MAPPINGS_REPO = 'cress-mappings'; // Option 2 target repo name
+
+const getToken = (): string | null =>
+  window.localStorage.getItem(TOKEN_KEY) || null;
+
+const getOwner = (): string =>
+  window.localStorage.getItem(USERNAME_KEY) || '';
+
+/**
+ * Map a Cress document's display name to the storage path (the key used on both
+ * ends: GitHub filename AND the PouchDbLocalStore path/name). MUST be applied
+ * identically at the load point and the save point, or the two ends desync.
+ *
+ * - GitHub contents API treats '/' and '\' as directory separators, so they are
+ *   replaced. Whitespace is collapsed. Unicode/spaces are otherwise preserved
+ *   (contentsUrl() URL-encodes the path).
+ * - listFiles() only returns *.csv, and listMappings() merges remote paths with
+ *   local names by string equality, so the path must end in '.csv' on both ends.
+ */
+export function nameToPath(name: string): string {
+  const base = name
+    .trim()
+    .replace(/[/\\]+/g, '-')
+    .replace(/\s+/g, ' ');
+  return base.toLowerCase().endsWith('.csv') ? base : `${base}.csv`;
+}
+
+// Lazy singleton: assembled on first use, by which point the editor load flow
+// has run and the login state (token + username in localStorage) is settled.
+let _instance: MappingStorage | null = null;
+let _backend: GitHubUserRepoBackend | null = null;
+
+export function getMappingStorage(): MappingStorage {
+  if (_instance) return _instance;
+
+  // Option 2 (default, end-to-end verified). To demo Option 1, replace _backend
+  // below with:
+  //   new WorkerBackend({ fetch: window.fetch.bind(window), getToken,
+  //                       workerUrl: '<lab worker url>' })
+  // and drop the ensureReady() repo-creation step (the Worker owns the repo).
+  _backend = new GitHubUserRepoBackend({
+    fetch: window.fetch.bind(window),
+    getToken,
+    owner: getOwner(), // read once at first use; editor login state is settled by then
+    repo: MAPPINGS_REPO,
+  });
+
+  _instance = new MappingStorage({
+    backend: _backend,
+    local: new PouchDbLocalStore(),
+    getToken,
+  });
+  return _instance;
+}
+
+/**
+ * Ensure the remote is ready to receive the first write. For Option 2 this
+ * creates the user's `cress-mappings` repo if missing (idempotent). No-op when
+ * logged out (we'll just save locally) or when the backend has no such concept
+ * (e.g. WorkerBackend, where the lab owns the repo).
+ *
+ * Call once before the first saveMapping() of a session. ensureRepo() is NOT on
+ * the StorageBackend interface (it's Option-2-specific), so the asymmetry is
+ * hidden here in the wiring layer rather than leaking into the save call site.
+ */
+export async function ensureReady(): Promise<void> {
+  if (!getToken()) return; // logged out -> local fallback, nothing to provision
+  getMappingStorage(); // make sure _backend is assembled
+  if (_backend && typeof _backend.ensureRepo === 'function') {
+    await _backend.ensureRepo();
+  }
+}
+
+// For the rare case login state changes within a live page (e.g. user logs in
+// without a reload) and the backend must pick up the new owner/token.
+export function resetMappingStorage(): void {
+  _instance = null;
+  _backend = null;
+}

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -27,8 +27,7 @@ const MAPPINGS_REPO = 'cress-mappings'; // Option 2 target repo name
 const getToken = (): string | null =>
   window.localStorage.getItem(TOKEN_KEY) || null;
 
-const getOwner = (): string =>
-  window.localStorage.getItem(USERNAME_KEY) || '';
+const getOwner = (): string => window.localStorage.getItem(USERNAME_KEY) || '';
 
 /**
  * Map a Cress document's display name to the storage path (the key used on both

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -8,7 +8,7 @@
 //
 // AUTH CONTRACT (shared with the OAuth frontend on feat/github-oauth-frontend):
 //   localStorage 'cress_github_token'    -> bearer token (null when logged out)
-//   localStorage 'cress_github_username' -> GitHub login (repo owner for Option 2)
+//   localStorage 'cress_github_username' -> GitHub login (repo owner)
 // We read these keys directly instead of importing getGithubToken(), so this
 // branch (feat/github-storage) does NOT depend on the OAuth branch's symbols.
 // AFTER the OAuth PR merges into main, swap getToken below for the imported
@@ -17,12 +17,12 @@
 import { MappingStorage } from './MappingStorage';
 import { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
 import { PouchDbLocalStore } from './PouchDbLocalStore';
-// Option 1 (Worker) -- swap in at the assembly line below if the meeting picks it.
+// To route writes through a Worker instead, swap in WorkerBackend at the assembly line below.
 // import { WorkerBackend } from './WorkerBackend';
 
 const TOKEN_KEY = 'cress_github_token';
 const USERNAME_KEY = 'cress_github_username';
-const MAPPINGS_REPO = 'cress-mappings'; // Option 2 target repo name
+const MAPPINGS_REPO = 'cress-mappings'; // target repo name
 
 const getToken = (): string | null =>
   window.localStorage.getItem(TOKEN_KEY) || null;
@@ -61,8 +61,8 @@ let _backend: GitHubUserRepoBackend | null = null;
 export function getMappingStorage(): MappingStorage {
   if (_instance) return _instance;
 
-  // Option 2 (default, end-to-end verified). To demo Option 1, replace _backend
-  // below with:
+  // Default backend writes directly to the user's repo (end-to-end verified).
+  // To route through a Worker instead, replace _backend below with:
   //   new WorkerBackend({ fetch: window.fetch.bind(window), getToken,
   //                       workerUrl: '<lab worker url>' })
   // and drop the ensureReady() repo-creation step (the Worker owns the repo).
@@ -82,13 +82,13 @@ export function getMappingStorage(): MappingStorage {
 }
 
 /**
- * Ensure the remote is ready to receive the first write. For Option 2 this
- * creates the user's `cress-mappings` repo if missing (idempotent). No-op when
+ * Ensure the remote is ready to receive the first write. This creates the
+ * user's `cress-mappings` repo if missing (idempotent). No-op when
  * logged out (we'll just save locally) or when the backend has no such concept
  * (e.g. WorkerBackend, where the lab owns the repo).
  *
  * Call once before the first saveMapping() of a session. ensureRepo() is NOT on
- * the StorageBackend interface (it's Option-2-specific), so the asymmetry is
+ * the StorageBackend interface (only this backend needs it), so the asymmetry is
  * hidden here in the wiring layer rather than leaking into the save call site.
  */
 export async function ensureReady(): Promise<void> {

--- a/src/Dashboard/githubStorage/cressRows.ts
+++ b/src/Dashboard/githubStorage/cressRows.ts
@@ -1,0 +1,67 @@
+// cressRows.ts
+// Bridges Cress's INTERNAL table representation and the CSV layer.
+//
+// Cress internal format (see Storage.ts createJson / updateAttachment):
+//   a JSON array shaped as [headers, ...rows], where:
+//     - headers is string[]            e.g. ["classification", "name", "mei", "image"]
+//     - each row is an OBJECT keyed by header
+//                                      e.g. { classification: "neume.pes", name: "pes", ... }
+//   The PouchDB attachment stores JSON.stringify([headers, ...rowObjects]).
+//
+// CSV layer (csv.ts) works on string[][]: row 0 = header cells, following rows
+// = data cells, all strings.
+//
+// This module converts between the two so the storage orchestration can keep
+// CSV on the wire (what GitHub stores and what Rodan's MEI Conversion Job
+// consumes) while Cress keeps its object-per-row shape in memory / PouchDB.
+
+import { CsvRow } from './csv';
+
+/** Cress's in-memory table payload: [headers, ...rowObjects]. */
+export type CressTablePayload = [string[], ...Array<Record<string, unknown>>];
+
+/**
+ * Convert Cress's [headers, ...rowObjects] into string[][] (header row first),
+ * ready for rowsToCsv(). Missing keys become "". Values are stringified;
+ * null/undefined become "".
+ */
+export function cressPayloadToRows(payload: CressTablePayload): CsvRow[] {
+  if (!Array.isArray(payload) || payload.length === 0) return [];
+  const headers = payload[0];
+  if (!Array.isArray(headers)) {
+    throw new Error(
+      'cressPayloadToRows: first element must be the header array',
+    );
+  }
+
+  const out: CsvRow[] = [headers.slice()];
+  for (let i = 1; i < payload.length; i++) {
+    const rowObj = payload[i] as Record<string, unknown>;
+    const cells = headers.map((h) => {
+      const v = rowObj ? rowObj[h] : undefined;
+      return v == null ? '' : String(v);
+    });
+    out.push(cells);
+  }
+  return out;
+}
+
+/**
+ * Convert string[][] (header row first) back into Cress's
+ * [headers, ...rowObjects]. Extra cells beyond the header length are dropped;
+ * short rows fill missing trailing columns with "".
+ */
+export function rowsToCressPayload(rows: CsvRow[]): CressTablePayload {
+  if (rows.length === 0) return [[]];
+  const headers = rows[0].slice();
+  const rowObjects: Array<Record<string, string>> = [];
+  for (let i = 1; i < rows.length; i++) {
+    const cells = rows[i];
+    const obj: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      obj[h] = idx < cells.length ? cells[idx] : '';
+    });
+    rowObjects.push(obj);
+  }
+  return [headers, ...rowObjects];
+}

--- a/src/Dashboard/githubStorage/csv.ts
+++ b/src/Dashboard/githubStorage/csv.ts
@@ -1,0 +1,105 @@
+// csv.ts
+// Pure CSV serialization / parsing. No Handsontable / ExportTools dependency yet.
+// When wiring into Cress, the data source (Handsontable rows / ExportTools output)
+// feeds rowsToCsv(); these functions stay unchanged.
+//
+// Follows RFC 4180:
+//   - fields containing comma, double-quote, CR or LF are wrapped in double quotes
+//   - embedded double-quotes are escaped by doubling them ("")
+//
+// NOTE on neume images: in Cress the image column holds a base64-encoded string
+// (sometimes itself containing commas inside a data URI / JSON-ish "[]"). Those are
+// just field contents as far as CSV is concerned, so escaping handles them.
+
+export type CsvRow = string[];
+
+const NEEDS_QUOTING = /[",\r\n]/;
+
+function escapeField(field: string): string {
+  if (NEEDS_QUOTING.test(field)) {
+    return '"' + field.replace(/"/g, '""') + '"';
+  }
+  return field;
+}
+
+/** Serialize a 2D array of strings to a CSV string. First row is treated as data
+ *  (caller decides whether row 0 is a header). Uses \r\n line endings per RFC 4180. */
+export function rowsToCsv(rows: CsvRow[]): string {
+  return rows.map((row) => row.map(escapeField).join(',')).join('\r\n');
+}
+
+/** Parse a CSV string back into a 2D array of strings. Handles quoted fields,
+ *  escaped quotes, and embedded commas / newlines. Accepts \n or \r\n. */
+export function csvToRows(csv: string): CsvRow[] {
+  const rows: CsvRow[] = [];
+  let field = '';
+  let row: CsvRow = [];
+  let inQuotes = false;
+  let i = 0;
+
+  // Strip a leading UTF-8 BOM if present.
+  if (csv.charCodeAt(0) === 0xfeff) i = 1;
+
+  const pushField = () => {
+    row.push(field);
+    field = '';
+  };
+  const pushRow = () => {
+    pushField();
+    rows.push(row);
+    row = [];
+  };
+
+  while (i < csv.length) {
+    const c = csv[i];
+
+    if (inQuotes) {
+      if (c === '"') {
+        if (csv[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      field += c;
+      i++;
+      continue;
+    }
+
+    if (c === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+    if (c === ',') {
+      pushField();
+      i++;
+      continue;
+    }
+    if (c === '\r') {
+      // handle \r\n and lone \r
+      if (csv[i + 1] === '\n') i++;
+      pushRow();
+      i++;
+      continue;
+    }
+    if (c === '\n') {
+      pushRow();
+      i++;
+      continue;
+    }
+    field += c;
+    i++;
+  }
+
+  // Flush trailing field/row unless the input ended exactly on a newline with
+  // nothing after it (avoid a spurious empty final row).
+  if (field.length > 0 || row.length > 0) {
+    pushRow();
+  }
+
+  return rows;
+}

--- a/src/Dashboard/githubStorage/index.ts
+++ b/src/Dashboard/githubStorage/index.ts
@@ -1,0 +1,29 @@
+// index.ts
+// Public surface of the githubStorage module. Matches the barrel pattern used
+// by Dashboard/FileSystem/index.ts.
+
+export { rowsToCsv, csvToRows } from './csv';
+export type { CsvRow } from './csv';
+
+export { cressPayloadToRows, rowsToCressPayload } from './cressRows';
+export type { CressTablePayload } from './cressRows';
+
+export { ConflictError, NotAuthenticatedError } from './backend';
+export type {
+  StorageBackend,
+  StoredFileMeta,
+  ReadResult,
+  WriteResult,
+} from './backend';
+
+export { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
+export type { GitHubBackendDeps } from './GitHubUserRepoBackend';
+
+export { MappingStorage, InMemoryLocalStore } from './MappingStorage';
+export type {
+  LocalStore,
+  MappingStorageDeps,
+  SaveOutcome,
+} from './MappingStorage';
+
+export { PouchDbLocalStore } from './PouchDbLocalStore';

--- a/src/Dashboard/githubStorage/index.ts
+++ b/src/Dashboard/githubStorage/index.ts
@@ -19,6 +19,9 @@ export type {
 export { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
 export type { GitHubBackendDeps } from './GitHubUserRepoBackend';
 
+export { WorkerBackend } from './WorkerBackend';
+export type { WorkerBackendDeps } from './WorkerBackend';
+
 export { MappingStorage, InMemoryLocalStore } from './MappingStorage';
 export type {
   LocalStore,

--- a/src/Editor/CressTable.ts
+++ b/src/Editor/CressTable.ts
@@ -41,12 +41,7 @@ export class CressTable {
   private savePath: string;
 
   // constructor(id: string, inputHeader: string[], body: any[]) {
-  constructor(
-    id: string,
-    name: string,
-    inputHeader: string[],
-    body: any[],
-  ) {
+  constructor(id: string, name: string, inputHeader: string[], body: any[]) {
     // const container = document.getElementById('hot-container');
     const container = document.getElementById('hot-container');
     this.savePath = nameToPath(name);
@@ -171,47 +166,50 @@ export class CressTable {
       });
 
     document.getElementById('save').addEventListener('click', async () => {
-          await this.saveTable(inputHeader, body);
-        });
+      await this.saveTable(inputHeader, body);
+    });
 
     document.body.addEventListener('keydown', async (evt) => {
-          if (evt.key === 's') {
-            await this.saveTable(inputHeader, body);
-          }
-        });
+      if (evt.key === 's') {
+        await this.saveTable(inputHeader, body);
+      }
+    });
   }
   private async saveTable(inputHeader: string[], body: any[]): Promise<void> {
-      try {
-        // Create the user's mappings repo on first save (no-op if it exists or
-        // logged out). The Option-2 asymmetry is hidden in the wiring layer.
-        await ensureReady();
+    try {
+      // Create the user's mappings repo on first save (no-op if it exists or
+      // logged out). The Option-2 asymmetry is hidden in the wiring layer.
+      await ensureReady();
 
-        // Cress internal [headers, ...rowObjects] -> string[][] for the CSV layer.
-        const payload = [inputHeader, ...body] as [
-          string[],
-          ...Array<Record<string, unknown>>,
-        ];
-        const rows = cressPayloadToRows(payload);
+      // Cress internal [headers, ...rowObjects] -> string[][] for the CSV layer.
+      const payload = [inputHeader, ...body] as [
+        string[],
+        ...Array<Record<string, unknown>>,
+      ];
+      const rows = cressPayloadToRows(payload);
 
-        const outcome = await getMappingStorage().saveMapping(this.savePath, rows);
+      const outcome = await getMappingStorage().saveMapping(
+        this.savePath,
+        rows,
+      );
 
-        if (outcome.status === 'conflict') {
-          setSavedStatus(false);
-          Notification.queueNotification(
-            'Save conflict: the remote file changed',
-            'error',
-          );
-          return;
-        }
-
-        setSavedStatus(true);
-        Notification.queueNotification('Saved', 'success');
-      } catch (e) {
-        console.error('saveTable failed:', e);
+      if (outcome.status === 'conflict') {
         setSavedStatus(false);
-        Notification.queueNotification('Save failed', 'error');
+        Notification.queueNotification(
+          'Save conflict: the remote file changed',
+          'error',
+        );
+        return;
       }
+
+      setSavedStatus(true);
+      Notification.queueNotification('Saved', 'success');
+    } catch (e) {
+      console.error('saveTable failed:', e);
+      setSavedStatus(false);
+      Notification.queueNotification('Save failed', 'error');
     }
+  }
 
   private initChangeListener() {
     changeHooks.forEach((hook) => {

--- a/src/Editor/CressTable.ts
+++ b/src/Editor/CressTable.ts
@@ -1,3 +1,10 @@
+import {
+  getMappingStorage,
+  ensureReady,
+  nameToPath,
+} from '../Dashboard/githubStorage/createMappingStorage';
+import { cressPayloadToRows } from '../Dashboard/githubStorage';
+
 import Handsontable from 'handsontable';
 import { ImageTools } from './ImageTools';
 import { MeiTools } from './MeiTools';
@@ -31,9 +38,18 @@ export class CressTable {
   private columnTools: ColumnTools;
   private defaultHeader = ['image', 'name', 'classification', 'mei'];
   private filterSidebar: FilterSidebar | null = null;
+  private savePath: string;
 
-  constructor(id: string, inputHeader: string[], body: any[]) {
+  // constructor(id: string, inputHeader: string[], body: any[]) {
+  constructor(
+    id: string,
+    name: string,
+    inputHeader: string[],
+    body: any[],
+  ) {
+    // const container = document.getElementById('hot-container');
     const container = document.getElementById('hot-container');
+    this.savePath = nameToPath(name);
 
     // Initialize Toolss
     this.imageTools = new ImageTools(this.images);
@@ -155,29 +171,47 @@ export class CressTable {
       });
 
     document.getElementById('save').addEventListener('click', async () => {
-      const result = await updateAttachment(id, [inputHeader, ...body]);
-
-      if (result) {
-        setSavedStatus(true);
-        Notification.queueNotification('Saved', 'success');
-      } else {
-        Notification.queueNotification('Save failed', 'error');
-      }
-    });
+          await this.saveTable(inputHeader, body);
+        });
 
     document.body.addEventListener('keydown', async (evt) => {
-      if (evt.key === 's') {
-        const result = await updateAttachment(id, [inputHeader, ...body]);
-
-        if (result) {
-          setSavedStatus(true);
-          Notification.queueNotification('Saved', 'success');
-        } else {
-          Notification.queueNotification('Save failed', 'error');
-        }
-      }
-    });
+          if (evt.key === 's') {
+            await this.saveTable(inputHeader, body);
+          }
+        });
   }
+  private async saveTable(inputHeader: string[], body: any[]): Promise<void> {
+      try {
+        // Create the user's mappings repo on first save (no-op if it exists or
+        // logged out). The Option-2 asymmetry is hidden in the wiring layer.
+        await ensureReady();
+
+        // Cress internal [headers, ...rowObjects] -> string[][] for the CSV layer.
+        const payload = [inputHeader, ...body] as [
+          string[],
+          ...Array<Record<string, unknown>>,
+        ];
+        const rows = cressPayloadToRows(payload);
+
+        const outcome = await getMappingStorage().saveMapping(this.savePath, rows);
+
+        if (outcome.status === 'conflict') {
+          setSavedStatus(false);
+          Notification.queueNotification(
+            'Save conflict: the remote file changed',
+            'error',
+          );
+          return;
+        }
+
+        setSavedStatus(true);
+        Notification.queueNotification('Saved', 'success');
+      } catch (e) {
+        console.error('saveTable failed:', e);
+        setSavedStatus(false);
+        Notification.queueNotification('Save failed', 'error');
+      }
+    }
 
   private initChangeListener() {
     changeHooks.forEach((hook) => {


### PR DESCRIPTION
Moves the `.csv` suffix to the GitHub backend boundary.

- Callers (MappingStorage, PouchDbLocalStore, nameToPath) use bare names, so the logged-out PouchDB lookup keeps matching.
- The GitHub backend adds `.csv` on read/write/delete and strips it from `listFiles` output.

## Verified

- Save: file lands on GitHub as `<name>.csv` with clean CSV content.
- Read-back: edited a value directly on GitHub and confirmed it loads back into Cress (proves the read path goes through the remote, not local).

## Still open (not in this PR)

- Delete/list dashboard wiring. Deleting in the dashboard currently removes the local PouchDB copy only; the GitHub copy is untouched until `deleteMapping` is wired.
- Option 1 vs Option 2 backend decision (pending meeting).
- Logged-in path was verified with a manually supplied token, not the real OAuth login UI.