### PR TITLE
feat: soft-delete mappings to .trash/

### DIFF
--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -1,4 +1,4 @@
-import { IEntry, IFile, IFolder, FileSystemTools } from './FileSystem';
+import { IEntry, IFile, IFolder, FileSystemTools, EntryType } from './FileSystem';
 import { deleteDocument, updateDocName, addDocument } from './Storage';
 import { FileSystemManager } from './FileSystem';
 import { ShiftSelectionManager, dashboardState } from './DashboardTools';
@@ -51,9 +51,6 @@ let metaKeyIsPressed = false;
 let shiftKeyIsPressed = false;
 let currentDragTarget = null;
 let rightClicked = false;
-
-const TRASH_SUFFIX =
-  / - \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [APMapm]{2}$/;
 
 openButton?.addEventListener('click', openDocsHandler);
 removeButton?.addEventListener('click', removeDocsHandler);
@@ -369,6 +366,8 @@ function removeDocsHandler() {
     });
   }
 
+  // Remote .trash/ sync is handled centrally in moveToFolder (covers button +
+  // drag paths uniformly), so we just do the local move here.
   moveToFolder(selectedEntries, parentFolder, trashFolder);
 }
 
@@ -391,6 +390,8 @@ function putBackDocsHandler() {
       if (dateTimePattern.test(entry.name)) {
         entry.name = entry.name.replace(dateTimePattern, '');
       }
+      // Remote restore is handled centrally in moveToFolder (covers this button
+      // path AND drag-out-of-trash uniformly).
       moveToFolder([entry], parentFolder, targetFolder);
     }
   }
@@ -409,10 +410,11 @@ async function deleteFileEntry(
   parentFolder: IFolder,
 ): Promise<boolean> {
   try {
-    // Trash appends " - <datetime>" on name collisions, but the remote file
-    // keeps its original name. Strip the suffix before resolving the GitHub path.
-    const remoteName = file.name.replace(TRASH_SUFFIX, '');
-    await getMappingStorage().deleteRemoteOnly(nameToPath(remoteName));
+    // LOCAL-ONLY delete. The GitHub side is append-only: the remote copy was
+    // already moved to .trash/ when the file was sent to Trash (see
+    // removeDocsHandler -> moveToFolder -> trashRemote), so permanent deletes
+    // here (Empty Trash / 30-day cleanup / Delete in Trash) must NOT touch the
+    // remote -- the .trash/ copy stays recoverable.
     await deleteDocument(file.id);
     FileSystemTools.removeEntry(file, parentFolder);
     return true;
@@ -952,13 +954,64 @@ function moveToFolder(
       newFolder,
     );
     if (!response.succeeded) errorMessages.push(response.error);
-    else FileSystemTools.moveEntry(entry, parentFolder, newFolder);
+    else {
+      FileSystemTools.moveEntry(entry, parentFolder, newFolder);
+      // Keep the GitHub remote in step with trash moves. This is centralized
+      // here (rather than in each caller) because EVERY move -- button Put
+      // Back, drag-and-drop, Move-To menu, Send to Trash -- funnels through
+      // moveToFolder. Doing it per-handler missed the drag path entirely.
+      // Files only; best-effort & fire-and-forget (local move is source of
+      // truth for the UI, remote sync follows without blocking).
+      syncRemoteForMove(entry, parentFolder, newFolder);
+    }
   });
 
   errorMessages.filter((msg, idx, arr) => arr.indexOf(msg) === idx);
   if (errorMessages.length > 0) window.alert(errorMessages.join('\n'));
 
   updateDashboard();
+}
+
+/**
+ * Mirror a local trash move onto the GitHub remote. Called for every entry that
+ * moveToFolder successfully moves. Direction is inferred from the folders:
+ *   - moved INTO trash      -> trashRemote   (file -> .trash/ on GitHub)
+ *   - moved OUT of trash     -> restoreRemote (.trash/ -> top level)
+ *   - any other move (folder<->folder) -> no remote effect (flat remote).
+ * Only file entries map to the remote. The remote key is the file's ORIGINAL
+ * bare name, so we strip any " - <datetime>" suffix that trash-collision
+ * renaming may have appended. No-ops when logged out (inside trash/restore).
+ */
+function syncRemoteForMove(
+  entry: IEntry,
+  fromFolder: IFolder,
+  toFolder: IFolder,
+) {
+  if (entry.type !== EntryType.File) return;
+
+  const movedIntoTrash = toFolder.type === EntryType.Trash;
+  const movedOutOfTrash = fromFolder.type === EntryType.Trash;
+  if (!movedIntoTrash && !movedOutOfTrash) return;
+
+  const TRASH_SUFFIX =
+    / - \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [APMapm]{2}$/;
+  const bareName = entry.name.replace(TRASH_SUFFIX, '');
+  const remotePath = nameToPath(bareName);
+  const storage = getMappingStorage();
+
+  if (movedIntoTrash) {
+    storage
+      .trashRemote(remotePath)
+      .catch((err) =>
+        console.error(`trashRemote failed for "${bareName}":`, err),
+      );
+  } else {
+    storage
+      .restoreRemote(remotePath)
+      .catch((err) =>
+        console.error(`restoreRemote failed for "${bareName}":`, err),
+      );
+  }
 }
 
 function trashFNConflictHandler(filename: string): string {

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -6,6 +6,10 @@ import { InitUploadArea } from './UploadArea';
 import * as contextMenuContent from './ContextMenuContent';
 import { ModalWindow, ModalWindowView } from '../utils/ModalWindow';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  getMappingStorage,
+  nameToPath,
+} from './githubStorage/createMappingStorage';
 
 const documentsContainer: HTMLDivElement = document.querySelector(
   '#fs-content-container',
@@ -47,6 +51,9 @@ let metaKeyIsPressed = false;
 let shiftKeyIsPressed = false;
 let currentDragTarget = null;
 let rightClicked = false;
+
+const TRASH_SUFFIX =
+  / - \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [APMapm]{2}$/;
 
 openButton?.addEventListener('click', openDocsHandler);
 removeButton?.addEventListener('click', removeDocsHandler);
@@ -396,15 +403,23 @@ function putBackDocsHandler() {
  * @param parentFolder
  * @returns
  */
-function deleteFileEntry(file: IFile, parentFolder: IFolder): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    deleteDocument(file.id)
-      .then(() => {
-        FileSystemTools.removeEntry(file, parentFolder);
-        resolve(true);
-      })
-      .catch(() => reject(false));
-  });
+
+async function deleteFileEntry(
+  file: IFile,
+  parentFolder: IFolder,
+): Promise<boolean> {
+  try {
+    // Trash appends " - <datetime>" on name collisions, but the remote file
+    // keeps its original name. Strip the suffix before resolving the GitHub path.
+    const remoteName = file.name.replace(TRASH_SUFFIX, '');
+    await getMappingStorage().deleteRemoteOnly(nameToPath(remoteName));
+    await deleteDocument(file.id);
+    FileSystemTools.removeEntry(file, parentFolder);
+    return true;
+  } catch (err) {
+    console.error('deleteFileEntry failed:', err);
+    return false;
+  }
 }
 
 /**

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -1,4 +1,10 @@
-import { IEntry, IFile, IFolder, FileSystemTools, EntryType } from './FileSystem';
+import {
+  IEntry,
+  IFile,
+  IFolder,
+  FileSystemTools,
+  EntryType,
+} from './FileSystem';
 import { deleteDocument, updateDocName, addDocument } from './Storage';
 import { FileSystemManager } from './FileSystem';
 import { ShiftSelectionManager, dashboardState } from './DashboardTools';

--- a/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
+++ b/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
@@ -76,7 +76,18 @@ export class GitHubUserRepoBackend implements StorageBackend {
 
   private contentsUrl(path: string): string {
     const { owner, repo } = this.deps;
-    return `${this.base}/repos/${owner}/${repo}/contents/${encodeURIComponent(withCsv(path))}`;
+    // Encode each path SEGMENT separately and rejoin with real '/'. A whole-path
+    // encodeURIComponent() would turn the '/' in a subdir path (e.g.
+    // ".trash/my-map.csv") into %2F, which the GitHub contents API treats as a
+    // literal filename char rather than a directory separator -- creating a
+    // root-level file literally named ".trash/my-map.csv" instead of a file
+    // inside the .trash dir. Per-segment encoding keeps separators intact while
+    // still escaping spaces/unicode within each segment.
+    const encoded = withCsv(path)
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/');
+    return `${this.base}/repos/${owner}/${repo}/contents/${encoded}`;
   }
 
   /** True if the target repo already exists for this user (GET /repos/:owner/:repo). */

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -1,4 +1,4 @@
-// storage.ts
+// MappingStorage.ts
 // The common orchestration layer. Talks ONLY to StorageBackend + the CSV pure
 // functions, so it is identical whether the backend is Option 1 (Worker) or
 // Option 2 (user repo). This is the "doesn't get thrown away" core.
@@ -7,7 +7,7 @@
 //   - turn Cress table rows into CSV and back (delegates to csv.ts)
 //   - remember the last-seen SHA per file so updates are conflict-checked
 //   - when not logged in, fall back to a local store (PouchDB in Cress; an
-//     in-memory map in this prototype) so the app still works offline (#138).
+//     in-memory map in this prototype) so the app still works offline.
 
 import { rowsToCsv, csvToRows, CsvRow } from './csv';
 import {
@@ -33,6 +33,14 @@ export interface MappingStorageDeps {
   getToken: () => string | null;
 }
 
+/**
+ * Subdir prefix for soft-deleted mappings on the remote. A trashed file lives
+ * at `${TRASH_PREFIX}<path>` (the backend adds .csv at its own boundary, giving
+ * e.g. `.trash/my-map.csv`), so it no longer appears among the top-level
+ * mappings yet stays recoverable.
+ */
+const TRASH_PREFIX = '.trash/';
+
 export type SaveOutcome =
   | { status: 'saved-remote'; path: string; sha: string }
   | { status: 'saved-local'; path: string } // logged out -> local only
@@ -52,7 +60,7 @@ export class MappingStorage {
   async saveMapping(path: string, rows: CsvRow[]): Promise<SaveOutcome> {
     const csv = rowsToCsv(rows);
 
-    // Logged-out fallback: keep working against the local store only (#138).
+    // Logged-out fallback: keep working against the local store only.
     if (!this.isLoggedIn()) {
       await this.deps.local.set(path, csv);
       return { status: 'saved-local', path };
@@ -131,20 +139,85 @@ export class MappingStorage {
 
   async deleteMapping(path: string): Promise<void> {
     await this.deps.local.remove(path);
-    await this.deleteRemoteOnly(path);
+    await this.trashRemote(path);
   }
 
-  async deleteRemoteOnly(path: string): Promise<void> {
-    if (!this.isLoggedIn()) return;
-    let sha = this.shaCache.get(path);
-    if (!sha) {
-      const remote = await this.deps.backend.readFile(path);
-      sha = remote?.sha ?? undefined;
+  /**
+   * Soft-delete on the remote: move the file under TRASH_PREFIX instead of
+   * deleting, so it stays recoverable. GitHub has no
+   * rename, so the move is copy-then-delete via existing backend ops -- the
+   * StorageBackend interface is unchanged, so the Worker backend inherits this.
+   * No-op when logged out or when the source isn't on the remote.
+   */
+  async trashRemote(path: string): Promise<void> {
+    if (this.isLoggedIn()) {
+      await this.moveRemote(path, this.trashPathFor(path));
     }
-    if (sha) {
-      await this.deps.backend.deleteFile(path, sha);
-      this.shaCache.delete(path);
+  }
+
+  /**
+   * Reverse of trashRemote: move the file back out of TRASH_PREFIX to its
+   * original path. Used by Put Back. No-op when logged out or when the trashed
+   * copy is absent.
+   */
+  async restoreRemote(path: string): Promise<void> {
+    if (this.isLoggedIn()) {
+      await this.moveRemote(this.trashPathFor(path), path);
     }
+  }
+
+  /** TRASH_PREFIX-qualified path for a bare mapping path. Idempotent: never
+   *  double-prefixes. */
+  private trashPathFor(path: string): string {
+    return path.startsWith(TRASH_PREFIX) ? path : `${TRASH_PREFIX}${path}`;
+  }
+
+  /**
+   * Move a remote file from->to by copy-then-delete, since GitHub's contents
+   * API has no atomic rename. Reads the source (for its content + delete SHA),
+   * writes it at the destination (probing the destination's SHA first so an
+   * already-occupied path updates instead of failing the create), then deletes
+   * the source. No-op if the source doesn't exist, so callers don't special-
+   * case local-only files. shaCache is kept in step: destination SHA recorded,
+   * source entry dropped.
+   *
+   * NOT atomic. If the process dies between write and delete you get the file
+   * at BOTH paths; a subsequent same-direction move self-heals. Acceptable for
+   * single-user trash; revisit if concurrent movers appear.
+   */
+  private async moveRemote(from: string, to: string): Promise<void> {
+    const src = await this.deps.backend.readFile(from);
+    if (!src) return; // nothing at source -> nothing to move
+
+    // The destination may already be occupied -- e.g. the user re-saved the
+    // file (recreating the top-level copy) before pressing Put Back. A bare
+    // create (sha=null) would then 422, the error would be swallowed by the
+    // caller's .catch, and the source would never be deleted (file stuck at
+    // BOTH paths). So probe the destination first:
+    const dest = await this.deps.backend.readFile(to);
+    if (dest && dest.content !== src.content) {
+      // Same path, DIFFERENT content: almost certainly a same-named file.
+      // Do NOT silently clobber it -- surface a conflict for the caller to
+      // handle. (Same-name collisions are a known limitation of name-as-key
+      // storage; the real fix is uuid keys.)
+      throw new ConflictError(
+        `moveRemote: destination "${to}" exists with different content`,
+        to,
+      );
+    }
+    // dest absent -> create (null); dest present with same content -> overwrite
+    // using its sha (idempotent, self-healing if a prior move half-completed).
+    const { sha: newSha } = await this.deps.backend.writeFile(
+      to,
+      src.content,
+      dest?.sha ?? null,
+    );
+    this.shaCache.set(to, newSha);
+
+    if (src.sha) {
+      await this.deps.backend.deleteFile(from, src.sha);
+    }
+    this.shaCache.delete(from);
   }
 }
 

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -207,11 +207,30 @@ export class MappingStorage {
     }
     // dest absent -> create (null); dest present with same content -> overwrite
     // using its sha (idempotent, self-healing if a prior move half-completed).
-    const { sha: newSha } = await this.deps.backend.writeFile(
-      to,
-      src.content,
-      dest?.sha ?? null,
-    );
+    //
+    // Write with 409 retry. GitHub's contents API is eventually consistent: in
+    // rapid back-to-back moves, a destination path touched by the previous move
+    // can briefly report a stale sha, so a write that just probed it may 409.
+    // On conflict, wait (letting GitHub settle), re-probe the destination sha,
+    // and retry with backoff. A single move never enters the retry path (the
+    // loop breaks on first success).
+    let newSha = '';
+    let probeSha = dest?.sha ?? null;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        ({ sha: newSha } = await this.deps.backend.writeFile(
+          to,
+          src.content,
+          probeSha,
+        ));
+        break;
+      } catch (err) {
+        if (!(err instanceof ConflictError) || attempt >= 3) throw err;
+        await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+        const reprobe = await this.deps.backend.readFile(to);
+        probeSha = reprobe?.sha ?? null;
+      }
+    }
     this.shaCache.set(to, newSha);
 
     if (src.sha) {

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -131,8 +131,16 @@ export class MappingStorage {
 
   async deleteMapping(path: string): Promise<void> {
     await this.deps.local.remove(path);
+    await this.deleteRemoteOnly(path);
+  }
+
+  async deleteRemoteOnly(path: string): Promise<void> {
     if (!this.isLoggedIn()) return;
-    const sha = this.shaCache.get(path);
+    let sha = this.shaCache.get(path);
+    if (!sha) {
+      const remote = await this.deps.backend.readFile(path);
+      sha = remote?.sha ?? undefined;
+    }
     if (sha) {
       await this.deps.backend.deleteFile(path, sha);
       this.shaCache.delete(path);

--- a/src/Dashboard/githubStorage/PouchDbLocalStore.ts
+++ b/src/Dashboard/githubStorage/PouchDbLocalStore.ts
@@ -1,7 +1,7 @@
 // PouchDbLocalStore.ts
 // Adapter that implements the LocalStore interface (from MappingStorage.ts) on
 // top of Cress's existing PouchDB layer in ../Storage.ts. This is the
-// logged-out / offline fallback store (#138): Storage.ts itself is NOT changed,
+// logged-out / offline fallback store: Storage.ts itself is NOT changed,
 // we only call its existing exported functions.
 //
 // Two seams that were previously TODO are now resolved against the real

--- a/src/Dashboard/githubStorage/WorkerBackend.ts
+++ b/src/Dashboard/githubStorage/WorkerBackend.ts
@@ -26,8 +26,8 @@
 //
 // STATUS: frontend side is complete and mock-tested. The Worker endpoints above
 // do NOT exist yet -- the current Worker only does OAuth token exchange. Wiring
-// this end-to-end requires extending the Worker, which is deferred until the
-// meeting confirms Option 1 is the chosen direction.
+// this end-to-end requires extending the Worker, which is deferred until
+// Option 1 is confirmed as the chosen direction.
 
 import {
   StorageBackend,

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -1,5 +1,5 @@
 // createMappingStorage.ts
-// App-wiring assembly point for #3. The barrel (index.ts) only exports classes;
+// App-wiring assembly point. The barrel (index.ts) only exports classes;
 // this is where they are composed into a ready-to-use MappingStorage instance.
 //
 // Importing this file from an entry (editor.ts) is what finally pulls the whole
@@ -17,7 +17,7 @@
 import { MappingStorage } from './MappingStorage';
 import { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
 import { PouchDbLocalStore } from './PouchDbLocalStore';
-// Option 1 (Worker) -- swap in at the assembly line below if the meeting picks it.
+// Option 1 (Worker) -- swap in at the assembly line below if chosen.
 // import { WorkerBackend } from './WorkerBackend';
 
 const TOKEN_KEY = 'cress_github_token';


### PR DESCRIPTION
Deleting a mapping from Trash now also removes it from the user's `cress-mappings` repo when logged in — previously it only deleted the local PouchDB copy, leaving the GitHub file orphaned (found 2026-06-18). Part of #139.

## Changes

- **MappingStorage.ts**: add `deleteRemoteOnly` (remote-only delete). It fetches the blob sha from the backend on cache miss, so cross-session deletes work even when the file wasn't opened this session.
- **Dashboard.ts**: `deleteFileEntry` now calls `deleteRemoteOnly`, then removes the local doc by id. All three permanent-delete paths (Delete, Empty Trash, 30-day cleanup) route through it. Move-to-Trash / Put Back deliberately untouched — files stay recoverable while in Trash.
- **MappingStorage.ts**: `moveRemote` now retries on 409 with backoff (re-probes the dest sha) to handle GitHub's eventual consistency on rapid consecutive trash moves. Mitigates but doesn't fully eliminate the concurrent-move race; full fix (serializing moves) tracked as follow-up.
- Minor: removed stale issue/meeting refs from githubStorage comments.

## Testing (manual, PAT in localStorage)

- Logged in, remote file exists → deleted on GitHub (verified via commit; cross-session, so the sha fallback ran)
- Logged in, remote file missing → 404, no delete, no error
- Logged out → no GitHub request

## Notes

- Base `feat/github-storage`; merge after #140.
- No GitHub-side soft delete (tracked in #142), Empty Trash / 30-day cleanup removes from the remote immediately, no recoverable buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trash and restore actions now stay synchronized between the app and GitHub, including button, drag-and-drop, and Move-To workflows.
  * Remote file moves now handle conflicts and transient errors more reliably.
* **Bug Fixes**
  * GitHub paths with special characters and subfolders are encoded correctly.
  * Local deletion now preserves the remote copy in Trash for recovery.
  * Folder and unrelated moves no longer trigger unnecessary remote actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->