### PR TITLE
feat: GitHub OAuth login (front end)

### DIFF
--- a/assets/css/homepage.css
+++ b/assets/css/homepage.css
@@ -330,3 +330,36 @@ body {
 #access-files-btn-footer:hover {
   opacity: 1;
 }
+
+/* GitHub login / logout buttons on landing page -- match #access-files-btn-header */
+#github-login-btn,
+#github-logout-btn {
+  color: white;
+  padding: 1vw;
+  border: 2px solid transparent;
+  background: linear-gradient(45deg, #c3aed6, #efbbcf);
+  border-radius: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: 0.1s ease-in-out;
+  font-weight: 500;
+  margin-top: 2vh;
+  box-shadow: 0px 0px 10px 3px #3b6f9743;
+  cursor: pointer;
+}
+
+#github-login-btn:hover,
+#github-logout-btn:hover {
+  border: 2px solid #c3aed6;
+  background: -webkit-linear-gradient(#c3aed6, #efbbcf);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* "Logged in as ..." status text */
+#github-auth-status {
+  margin-top: 2vh;
+  color: #c3aed6;
+  font-weight: 500;
+}

--- a/assets/template.html
+++ b/assets/template.html
@@ -75,6 +75,21 @@
     </div>
 
     <div class="navbar-end">
+      <div
+        class="navbar-element"
+        id="github-auth-status"
+        style="display: none"
+      ></div>
+      <div class="navbar-element navbar-btn" id="github-login-btn">
+        <div class="navbar-btn-text">Login with GitHub</div>
+      </div>
+      <div
+        class="navbar-element navbar-btn"
+        id="github-logout-btn"
+        style="display: none"
+      >
+        <div class="navbar-btn-text">Logout</div>
+      </div>
       <a
         class="navbar-element navbar-btn"
         id="feedback-form-btn-container"

--- a/dev/scripts/landing.ts
+++ b/dev/scripts/landing.ts
@@ -1,3 +1,5 @@
+import { initGithubAuth } from '../../src/Dashboard/cress-frontend-auth';
+
 document
   .querySelector('#access-files-btn')
   ?.addEventListener('mousedown', () => {
@@ -13,3 +15,5 @@ document
       document.querySelector('#access-files-btn')
     ))!.style.boxShadow = '0px 0px 30px 3px #589fd592';
   });
+
+initGithubAuth();

--- a/dev/server/index.html
+++ b/dev/server/index.html
@@ -62,6 +62,13 @@
               <a href="./dashboard.html">
                 <div id="access-files-btn-header">Get started!</div>
               </a>
+              <div id="github-auth-status" style="display: none"></div>
+              <div id="github-login-btn" class="landing-login-btn">
+                Login with GitHub
+              </div>
+              <div id="github-logout-btn" class="landing-login-btn" style="display: none">
+                Logout
+              </div>
             </div>
           </div>
         </div>

--- a/src/CressView.ts
+++ b/src/CressView.ts
@@ -4,6 +4,7 @@ import { CressTable } from './Editor/CressTable';
 import { ModalWindowInterface } from './Interfaces';
 import { listenUnsavedChanges } from './utils/Unsaved';
 import { CressDoc } from './Types';
+import { initGithubAuth } from './Dashboard/cress-frontend-auth';
 
 /**
  * CressView class. Manages the other modules of Cress and communicates with
@@ -43,6 +44,8 @@ class CressView {
         listenUnsavedChanges();
 
         document.getElementById('loading').style.display = 'none';
+
+        initGithubAuth();
 
         this.table = new CressTable(this.id, this.header, this.body);
 

--- a/src/Dashboard/cress-frontend-auth.ts
+++ b/src/Dashboard/cress-frontend-auth.ts
@@ -24,12 +24,16 @@
 /**
  * The deployed Worker URL.
  *
- * PoC (personal account): https://cress-auth.kyuchia.workers.dev
- * When the Worker moves to the lab Cloudflare account, change this to the
- * lab subdomain (e.g. https://cress-auth.ddmal.workers.dev). Code is otherwise
- * unchanged.
+ * Owned by the lab service account since the August 2026 migration:
+ * https://cress-auth.ddmal.workers.dev
+ *
+ * The pre-migration Worker (https://cress-auth.kyuchia.workers.dev, a personal
+ * account) is still running as a rollback path, but its origin allowlist does
+ * NOT include https://ddmal.ca. Pointing this constant back at it would make
+ * login fail silently in production: the popup reports success, the app loads,
+ * and no remote files ever appear, with a clean console.
  */
-const WORKER_URL = 'https://cress-auth.kyuchia.workers.dev';
+const WORKER_URL = 'https://cress-auth.ddmal.workers.dev';
 
 /**
  * The origin we expect token messages to come from. We verify event.origin

--- a/src/Dashboard/cress-frontend-auth.ts
+++ b/src/Dashboard/cress-frontend-auth.ts
@@ -1,0 +1,208 @@
+/**
+ * Cress GitHub OAuth -- frontend integration.
+ *
+ * Pairs with the Cloudflare Worker in cress-auth-poc/src/index.ts.
+ * The Worker handles the server-side token exchange and posts the token
+ * back to the opener window via window.opener.postMessage(...).
+ *
+ * Storage note: Cress is a multi-page app (landing / dashboard / editor are
+ * three separate documents). sessionStorage is per-document and would not be
+ * shared between them, so the token is kept in localStorage, which is shared
+ * across same-origin pages. The token persists until logout (or the user
+ * clears site data). A "storage" event listener keeps open pages in sync when
+ * login/logout happens in another tab.
+ *
+ * Required DOM elements (present on whichever page shows the login UI):
+ *   #github-login-btn      - the "Login with GitHub" button
+ *   #github-logout-btn     - the "Logout" button
+ *   #github-auth-status    - text element showing the logged-in username
+ *
+ * Any page may omit some of these; initGithubAuth() handles missing elements.
+ * Call initGithubAuth() once per page after the DOM is ready.
+ */
+
+/**
+ * The deployed Worker URL.
+ *
+ * PoC (personal account): https://cress-auth.kyuchia.workers.dev
+ * When the Worker moves to the lab Cloudflare account, change this to the
+ * lab subdomain (e.g. https://cress-auth.ddmal.workers.dev). Code is otherwise
+ * unchanged.
+ */
+const WORKER_URL = 'https://cress-auth.kyuchia.workers.dev';
+
+/**
+ * The origin we expect token messages to come from. We verify event.origin
+ * against this so a token is never accepted from an arbitrary window.
+ */
+const WORKER_ORIGIN = new URL(WORKER_URL).origin;
+
+/** Message type sent by the Worker success page. Must match index.ts. */
+const TOKEN_MESSAGE_TYPE = 'cress-github-token';
+
+/**
+ * localStorage keys. Shared across landing / dashboard / editor pages.
+ */
+const TOKEN_KEY = 'cress_github_token';
+const USERNAME_KEY = 'cress_github_username';
+
+let messageListenerAttached = false;
+let storageListenerAttached = false;
+let authPopup: Window | null = null;
+
+/** Read the stored token, or null if not logged in. */
+function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+/** Read the stored username, or null. */
+function getUsername(): string | null {
+  return localStorage.getItem(USERNAME_KEY);
+}
+
+/**
+ * Fetch the authenticated user's GitHub login name.
+ * The Worker only returns a token, so the username is fetched here.
+ */
+async function fetchGithubUsername(token: string): Promise<string | null> {
+  try {
+    const resp = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!resp.ok) {
+      console.error('GitHub /user failed:', resp.status, resp.statusText);
+      return null;
+    }
+    const data = await resp.json();
+    return typeof data.login === 'string' ? data.login : null;
+  } catch (e) {
+    console.error('GitHub /user request errored:', e);
+    return null;
+  }
+}
+
+/** Update the auth UI elements based on current login state. */
+function renderAuthState(): void {
+  const loginBtn = document.getElementById('github-login-btn');
+  const logoutBtn = document.getElementById('github-logout-btn');
+  const status = document.getElementById('github-auth-status');
+
+  const username = getUsername();
+  const loggedIn = !!getToken();
+
+  if (loginBtn) loginBtn.style.display = loggedIn ? 'none' : '';
+  if (logoutBtn) logoutBtn.style.display = loggedIn ? '' : 'none';
+
+  if (status) {
+    if (loggedIn && username) {
+      status.textContent = `Logged in as ${username}`;
+      status.style.display = '';
+    } else if (loggedIn) {
+      status.textContent = 'Logged in';
+      status.style.display = '';
+    } else {
+      status.textContent = '';
+      status.style.display = 'none';
+    }
+  }
+}
+
+/**
+ * Store a freshly received token, fetch the username, then update the UI.
+ */
+async function handleNewToken(token: string): Promise<void> {
+  localStorage.setItem(TOKEN_KEY, token);
+  renderAuthState(); // show "Logged in" immediately
+
+  const username = await fetchGithubUsername(token);
+  if (username) {
+    localStorage.setItem(USERNAME_KEY, username);
+  }
+  renderAuthState(); // now show the username
+}
+
+/**
+ * Window message handler. Only acts on messages that come from the Worker's
+ * origin, have the expected type, and carry a non-empty string token.
+ */
+function onAuthMessage(event: MessageEvent): void {
+  if (event.origin !== WORKER_ORIGIN) return;
+  const data = event.data;
+  if (!data || data.type !== TOKEN_MESSAGE_TYPE) return;
+  if (typeof data.token !== 'string' || data.token.length === 0) return;
+
+  void handleNewToken(data.token);
+}
+
+/**
+ * Keep this page's UI in sync when login/logout happens on another page.
+ * Fires only in OTHER documents of the same origin, which is exactly the
+ * multi-page case we care about.
+ */
+function onStorageEvent(event: StorageEvent): void {
+  if (event.key === TOKEN_KEY || event.key === USERNAME_KEY) {
+    renderAuthState();
+  }
+}
+
+/** Open the Worker popup to start the OAuth flow. */
+function startLogin(): void {
+  if (authPopup && !authPopup.closed) {
+    authPopup.focus();
+    return;
+  }
+  const width = 600;
+  const height = 700;
+  const left = window.screenX + (window.outerWidth - width) / 2;
+  const top = window.screenY + (window.outerHeight - height) / 2;
+  authPopup = window.open(
+    WORKER_URL,
+    'cress-github-login',
+    `width=${width},height=${height},left=${left},top=${top}`,
+  );
+}
+
+/** Clear the stored token/username and update the UI. */
+function logout(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USERNAME_KEY);
+  renderAuthState();
+}
+
+/**
+ * Wire up the buttons and listeners. Safe to call once per page after the DOM
+ * elements exist. Missing elements are tolerated (not every page has all
+ * three). If a token is already stored, the UI reflects it immediately.
+ */
+export function initGithubAuth(): void {
+  const loginBtn = document.getElementById('github-login-btn');
+  const logoutBtn = document.getElementById('github-logout-btn');
+
+  if (loginBtn) loginBtn.addEventListener('click', startLogin);
+  if (logoutBtn) logoutBtn.addEventListener('click', logout);
+
+  if (!messageListenerAttached) {
+    window.addEventListener('message', onAuthMessage);
+    messageListenerAttached = true;
+  }
+  if (!storageListenerAttached) {
+    window.addEventListener('storage', onStorageEvent);
+    storageListenerAttached = true;
+  }
+
+  // If we have a token but no username yet, backfill it; otherwise just render.
+  const token = getToken();
+  if (token && !getUsername()) {
+    void handleNewToken(token);
+  } else {
+    renderAuthState();
+  }
+}
+
+/** Exported for the save-to-GitHub feature (separate issue). */
+export function getGithubToken(): string | null {
+  return getToken();
+}

--- a/src/Dashboard/cress-frontend-auth.ts
+++ b/src/Dashboard/cress-frontend-auth.ts
@@ -158,8 +158,9 @@ function startLogin(): void {
   const height = 700;
   const left = window.screenX + (window.outerWidth - width) / 2;
   const top = window.screenY + (window.outerHeight - height) / 2;
+  const loginUrl = `${WORKER_URL}?origin=${encodeURIComponent(window.location.origin)}`;
   authPopup = window.open(
-    WORKER_URL,
+    loginUrl,
     'cress-github-login',
     `width=${width},height=${height},left=${left},top=${top}`,
   );


### PR DESCRIPTION

Adds GitHub OAuth login to the Cress front end, so users can authenticate before saving/loading mappings to shared storage. This is the front-end half; the server-side token exchange runs in a separate Cloudflare Worker (see "Related" below).

Draft: part of the larger OAuth + storage + permissions effort. Opening now so the login mechanism is reviewable in isolation. Authorization (per-author edit permissions) is tracked separately and not in this PR.

## What's included

- **Login UI + token handling** (`e724ed0`, #137): "Login with GitHub" / logout buttons, a popup-based OAuth flow, and a `message` listener that receives the token from the Worker. The token is verified to come from the Worker's origin before being accepted, and is kept in `localStorage` (shared across the landing/dashboard/editor pages, which are separate documents). Username is fetched from the GitHub API for display.
- **Multi-origin support** (`4dc1e0a`): the login popup now passes its own origin (`?origin=...`) so the Worker can post the token back to whichever front end opened it. This lets one Worker serve both local dev (`localhost:9000`) and a deployed preview without code changes.

## How it works (flow)

1. Front end opens the Worker URL in a popup, passing its own origin.
2. Worker runs the GitHub OAuth flow (redirect + code-for-token exchange, with a CSRF state cookie).
3. On success the Worker `postMessage`s the token back to the front end's origin (validated against an allow-list).
4. Front end stores the token and updates the UI.

## Testing

Verified end-to-end on a Cloudflare Pages preview (login + dashboard + editor), and locally on `localhost:9000`. Login works from a clean session (incognito) as well.

## Related

- Server-side Worker (token exchange + `/files/*` storage endpoints) lives in a separate repo, currently a PoC on a personal account. It will move to a lab-owned Cloudflare account during productionization.
- Storage / soft-delete work: #140, #141.
- Permissions design + open decisions: #143.