### PR TITLE
fix: rebuild Your files from GitHub on dashboard load

### DIFF
--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -738,36 +738,6 @@ textarea.file-input {
   animation: settle 0.5s ease-in-out forwards;
 }
 
-.all-mappings-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 20px 0;
-}
-
-.all-mappings-back {
-  font-size: 14px;
-  font-weight: 900;
-  letter-spacing: 3px;
-  padding: 6px 8px;
-  border: 2px solid #c3aed6;
-  border-radius: 5px;
-  color: #c3aed6;
-  background-color: transparent;
-  cursor: pointer;
-}
-
-.all-mappings-back:hover {
-  color: #8675a9;
-  border-color: #8675a9;
-}
-
-.all-mappings-title {
-  font-size: calc(15px + 1vw);
-  color: #8675a9;
-  font-weight: 500;
-}
-
 .all-mappings-hint {
   color: #696969;
   font-size: 0.9rem;

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -724,3 +724,199 @@ textarea.file-input {
   font-size: 14px;
   cursor: pointer;
 }
+/* ==========================================================================
+ * View-all ("All Mappings") — Version C panel styling.
+ * Matches Cress's existing design language (see dashboard.css / style.css):
+ * purple #8675a9 (primary) + #c3aed6 (light), file cards like .file-entry,
+ * folder rows like .folder-entry, modal like #cress-modal-window.
+ * Montserrat, settle animation. Append to assets/css/dashboard.css.
+ * ======================================================================== */
+
+#all-mappings-panel {
+  display: none;
+  width: 90%;
+  animation: settle 0.5s ease-in-out forwards;
+}
+
+.all-mappings-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 20px 0;
+}
+
+.all-mappings-back {
+  font-size: 14px;
+  font-weight: 900;
+  letter-spacing: 3px;
+  padding: 6px 8px;
+  border: 2px solid #c3aed6;
+  border-radius: 5px;
+  color: #c3aed6;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.all-mappings-back:hover {
+  color: #8675a9;
+  border-color: #8675a9;
+}
+
+.all-mappings-title {
+  font-size: calc(15px + 1vw);
+  color: #8675a9;
+  font-weight: 500;
+}
+
+.all-mappings-hint {
+  color: #696969;
+  font-size: 0.9rem;
+  margin: 18px 0 10px;
+}
+
+.all-mappings-grid {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* ---- foreign user rows (expand/collapse) --------------------------------- */
+/* Styled like a .folder-entry card: purple, white text. */
+
+.foreign-user-row {
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.foreign-user-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: white;
+  background-color: #c3aed6;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  padding: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.foreign-user-header:hover {
+  border-color: #8675a9;
+}
+
+.foreign-user-chevron {
+  font-size: 0.8rem;
+  width: 1em;
+  text-align: center;
+}
+
+.foreign-user-name {
+  font-weight: 500;
+}
+
+.foreign-user-files {
+  padding: 12px 0 4px 8px;
+}
+
+/* ---- read-only foreign file tile ----------------------------------------- */
+/* Same as .file-entry (transparent, grey border/text) + copy button. */
+
+.foreign-tile {
+  cursor: default;
+  padding: 12px;
+  margin-right: 2vw;
+  margin-bottom: 2vw;
+  border: 2px solid #adadad;
+  border-radius: 4px;
+  background-color: transparent;
+  color: #696969;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  animation: settle 0.5s ease-in-out forwards;
+}
+
+.foreign-tile-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.foreign-tile-copy {
+  flex-shrink: 0;
+  border: 2px solid #c3aed6;
+  background-color: transparent;
+  color: #c3aed6;
+  border-radius: 5px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  font-family: Montserrat, sans-serif;
+  cursor: pointer;
+}
+
+.foreign-tile-copy:hover {
+  color: #8675a9;
+  border-color: #8675a9;
+}
+
+/* ---- same-name conflict dialog (Finder-style) ---------------------------- */
+/* Mirrors #cress-modal-window veil + header colours. */
+
+.copy-conflict-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #00000080;
+  z-index: 2147483647;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.copy-conflict-box {
+  background-color: white;
+  border-radius: 5px;
+  overflow: hidden;
+  min-width: 25vw;
+  max-width: 420px;
+  color: #9d9d9d;
+  font-family: Montserrat, sans-serif;
+  box-shadow: 0px 0px 10px 3px #cecece;
+}
+
+.copy-conflict-msg {
+  padding: 20px;
+  font-size: 0.95rem;
+  color: dimgrey;
+  line-height: 1.5;
+}
+
+.copy-conflict-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 0 20px 20px;
+}
+
+.copy-conflict-actions button {
+  background-color: #c3aed6;
+  color: white;
+  cursor: pointer;
+  padding: 6px 14px;
+  border: none;
+  border-radius: 4px;
+  font-weight: 900;
+  font-family: Montserrat, sans-serif;
+}
+
+.copy-conflict-actions button:hover {
+  background-color: #8675a9;
+}

--- a/assets/css/dashboard.css
+++ b/assets/css/dashboard.css
@@ -859,7 +859,7 @@ textarea.file-input {
   max-width: 420px;
   color: #9d9d9d;
   font-family: Montserrat, sans-serif;
-  box-shadow: 0px 0px 10px 3px #cecece;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
 }
 
 .copy-conflict-msg {

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -2201,7 +2201,7 @@ function showCopyConflictDialog(owner: string, path: string): void {
 
   const msg = document.createElement('div');
   msg.classList.add('copy-conflict-msg');
-  msg.innerText = `You already have a mapping named "${path}". What would you like to do?`;
+  msg.innerText = `An item named "${path}" already exists in your mappings. Do you want to replace it with the one you're copying?`;
   box.appendChild(msg);
 
   const actions = document.createElement('div');

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -1,4 +1,4 @@
-import { IEntry, IFile, IFolder, FileSystemTools } from './FileSystem';
+import { IEntry, IFile, IFolder, FileSystemTools, EntryType } from './FileSystem';
 import { deleteDocument, updateDocName, addDocument } from './Storage';
 import { FileSystemManager } from './FileSystem';
 import { ShiftSelectionManager, dashboardState } from './DashboardTools';
@@ -51,9 +51,6 @@ let metaKeyIsPressed = false;
 let shiftKeyIsPressed = false;
 let currentDragTarget = null;
 let rightClicked = false;
-
-const TRASH_SUFFIX =
-  / - \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [APMapm]{2}$/;
 
 openButton?.addEventListener('click', openDocsHandler);
 removeButton?.addEventListener('click', removeDocsHandler);
@@ -369,6 +366,8 @@ function removeDocsHandler() {
     });
   }
 
+  // Remote .trash/ sync is handled centrally in moveToFolder (covers button +
+  // drag paths uniformly), so we just do the local move here.
   moveToFolder(selectedEntries, parentFolder, trashFolder);
 }
 
@@ -391,6 +390,8 @@ function putBackDocsHandler() {
       if (dateTimePattern.test(entry.name)) {
         entry.name = entry.name.replace(dateTimePattern, '');
       }
+      // Remote restore is handled centrally in moveToFolder (covers this button
+      // path AND drag-out-of-trash uniformly).
       moveToFolder([entry], parentFolder, targetFolder);
     }
   }
@@ -409,10 +410,11 @@ async function deleteFileEntry(
   parentFolder: IFolder,
 ): Promise<boolean> {
   try {
-    // Trash appends " - <datetime>" on name collisions, but the remote file
-    // keeps its original name. Strip the suffix before resolving the GitHub path.
-    const remoteName = file.name.replace(TRASH_SUFFIX, '');
-    await getMappingStorage().deleteRemoteOnly(nameToPath(remoteName));
+    // LOCAL-ONLY delete. The GitHub side is append-only: the remote copy was
+    // already moved to .trash/ when the file was sent to Trash (see
+    // removeDocsHandler -> moveToFolder -> trashRemote), so permanent deletes
+    // here (Empty Trash / 30-day cleanup / Delete in Trash) must NOT touch the
+    // remote -- the .trash/ copy stays recoverable.
     await deleteDocument(file.id);
     FileSystemTools.removeEntry(file, parentFolder);
     return true;
@@ -952,13 +954,64 @@ function moveToFolder(
       newFolder,
     );
     if (!response.succeeded) errorMessages.push(response.error);
-    else FileSystemTools.moveEntry(entry, parentFolder, newFolder);
+    else {
+      FileSystemTools.moveEntry(entry, parentFolder, newFolder);
+      // Keep the GitHub remote in step with trash moves. This is centralized
+      // here (rather than in each caller) because EVERY move -- button Put
+      // Back, drag-and-drop, Move-To menu, Send to Trash -- funnels through
+      // moveToFolder. Doing it per-handler missed the drag path entirely.
+      // Files only; best-effort & fire-and-forget (local move is source of
+      // truth for the UI, remote sync follows without blocking).
+      syncRemoteForMove(entry, parentFolder, newFolder);
+    }
   });
 
   errorMessages.filter((msg, idx, arr) => arr.indexOf(msg) === idx);
   if (errorMessages.length > 0) window.alert(errorMessages.join('\n'));
 
   updateDashboard();
+}
+
+/**
+ * Mirror a local trash move onto the GitHub remote. Called for every entry that
+ * moveToFolder successfully moves. Direction is inferred from the folders:
+ *   - moved INTO trash      -> trashRemote   (file -> .trash/ on GitHub)
+ *   - moved OUT of trash     -> restoreRemote (.trash/ -> top level)
+ *   - any other move (folder<->folder) -> no remote effect (flat remote).
+ * Only file entries map to the remote. The remote key is the file's ORIGINAL
+ * bare name, so we strip any " - <datetime>" suffix that trash-collision
+ * renaming may have appended. No-ops when logged out (inside trash/restore).
+ */
+function syncRemoteForMove(
+  entry: IEntry,
+  fromFolder: IFolder,
+  toFolder: IFolder,
+) {
+  if (entry.type !== EntryType.File) return;
+
+  const movedIntoTrash = toFolder.type === EntryType.Trash;
+  const movedOutOfTrash = fromFolder.type === EntryType.Trash;
+  if (!movedIntoTrash && !movedOutOfTrash) return;
+
+  const TRASH_SUFFIX =
+    / - \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [APMapm]{2}$/;
+  const bareName = entry.name.replace(TRASH_SUFFIX, '');
+  const remotePath = nameToPath(bareName);
+  const storage = getMappingStorage();
+
+  if (movedIntoTrash) {
+    storage
+      .trashRemote(remotePath)
+      .catch((err) =>
+        console.error(`trashRemote failed for "${bareName}":`, err),
+      );
+  } else {
+    storage
+      .restoreRemote(remotePath)
+      .catch((err) =>
+        console.error(`restoreRemote failed for "${bareName}":`, err),
+      );
+  }
 }
 
 function trashFNConflictHandler(filename: string): string {

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -1841,6 +1841,9 @@ export const loadDashboard = async (): Promise<void> => {
   updateTrash(root);
   updateDashboard([root]);
   initializeDefaultContextMenu();
+  // Fire-and-forget: paint the local tree first for an instant dashboard, then
+  // top it up from GitHub in the background (stale-while-revalidate).
+  void reconcileTreeWithRemote();
 };
 
 /* ==========================================================================
@@ -2275,8 +2278,10 @@ function showCopyConflictDialog(owner: string, path: string): void {
 }
 
 /**
- * Materialize a just-copied mapping as a real FileSystem tree node so it appears
- * in "Your files" / My Mappings and opens in the editor.
+ * Materialize a mapping that exists in the user's own storage (a just-made
+ * copy, or a remote file found by reconcileTreeWithRemote) as a real
+ * FileSystem tree node so it appears in "Your files" / My Mappings and opens
+ * in the editor.
  *
  * Copying writes GitHub (source of truth) plus a name-keyed local mirror via
  * MappingStorage, but the dashboard renders UUID-keyed canonical docs from the
@@ -2338,6 +2343,68 @@ async function materializeCopyInTree(destName: string): Promise<void> {
   });
   FileSystemTools.addEntry(docEntry, root);
   updateDashboard();
+}
+
+/**
+ * Additive-only reconcile of the FileSystem tree against the user's GitHub
+ * repo, run in the background on dashboard load.
+ *
+ * The tree is local (PouchDB); saves dual-write GitHub + tree but nothing ever
+ * rebuilt the tree FROM GitHub, so a cleared IndexedDB / new device / fresh
+ * incognito session showed an empty "Your files" while the repo was intact.
+ * Here GitHub is treated as the source of truth for EXISTENCE: any remote
+ * mapping whose name appears nowhere in the tree (outside Trash / the shipped
+ * Samples folder) is materialized at root via the same path a copied mapping
+ * takes (materializeCopyInTree is idempotent for same-named root nodes).
+ *
+ * Deliberately additive-only for v1: local entries missing on the remote are
+ * left alone, because there is no dirty/unsynced marker yet -- deleting could
+ * destroy a local file that simply never synced. Deletion-side reconcile is a
+ * follow-up once such a marker exists. Names are compared against the WHOLE
+ * tree (any folder depth), because the remote is flat while the tree has
+ * folders: a mapping the user moved into a subfolder must not be re-added at
+ * root as a duplicate.
+ *
+ * Failures are swallowed with a console.warn -- if GitHub is unreachable the
+ * dashboard simply keeps showing the local tree as-is.
+ */
+async function reconcileTreeWithRemote(): Promise<void> {
+  try {
+    const remoteNames = await getMappingStorage().listRemoteMappings();
+    if (remoteNames.length === 0) return;
+
+    const root = state.getFolderPath().at(0);
+    if (!root) return;
+
+    // Every file name anywhere in the tree, excluding Trash and the top-level
+    // Samples folder (app-shipped samples are not user mappings; a user
+    // subfolder that happens to be named Samples still counts).
+    const treeNames = new Set<string>();
+    const walk = (folder: IFolder, isRoot: boolean): void => {
+      for (const entry of folder.children) {
+        if (entry.type === EntryType.Trash) continue;
+        if (entry.type === EntryType.Folder) {
+          if (isRoot && entry.name === 'Samples') continue;
+          walk(entry as IFolder, false);
+        } else {
+          treeNames.add(entry.name);
+        }
+      }
+    };
+    walk(root as IFolder, true);
+
+    for (const name of remoteNames) {
+      if (treeNames.has(name)) continue;
+      try {
+        await materializeCopyInTree(name);
+      } catch (err) {
+        console.warn(`reconcile: could not materialize "${name}":`, err);
+      }
+    }
+  } catch (err) {
+    // Never let reconcile break the dashboard; the local tree stays usable.
+    console.warn('reconcile with GitHub failed:', err);
+  }
 }
 
 /**

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -15,7 +15,9 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   getMappingStorage,
   nameToPath,
+  listIndexedForeignUsers,
 } from './githubStorage/createMappingStorage';
+import { ConflictError } from './githubStorage/backend';
 
 const documentsContainer: HTMLDivElement = document.querySelector(
   '#fs-content-container',
@@ -881,6 +883,14 @@ export async function updateDashboard(newPath?: IFolder[]): Promise<void> {
   });
 
   fsm.setFileSystem(state.getFolderPath().at(0));
+
+  // View-all entry point: only at the root level, alongside the top-level
+  // folders. Opens a self-managed overlay (see openAllMappings) rather than
+  // navigating the FileSystem tree, because foreign mappings come from GitHub
+  // storage and are not nodes in the IFolder tree.
+  if (state.getFolderPath().length === 1) {
+    appendAllMappingsEntry();
+  }
 }
 
 function addDragStartListener(elem: Element) {
@@ -1827,3 +1837,387 @@ export const loadDashboard = async (): Promise<void> => {
   updateDashboard([root]);
   initializeDefaultContextMenu();
 };
+
+/* ==========================================================================
+ * View-all ("All Mappings") — Version C
+ *
+ * A self-managed overlay panel, deliberately isolated from the FileSystem
+ * navigation tree (state.getFolderPath()). Foreign mappings come from GitHub
+ * storage, not from the IFolder tree, so wiring them into folderPath / the
+ * breadcrumb / Back would mean threading a "is this node foreign?" exception
+ * through the whole navigation core. Instead this panel shows/hides itself over
+ * the normal dashboard (the same idea as the trash info-badge, scaled up to a
+ * whole view) and has its own Back button.
+ *
+ * Your own files render as normal editable tiles at the top. Each other user is
+ * a row that expands/collapses in place to reveal their files as read-only
+ * tiles with a "Copy to my mappings" action.
+ * ======================================================================== */
+
+const ALL_MAPPINGS_ENTRY_ID = 'all-mappings-entry';
+const ALL_MAPPINGS_PANEL_ID = 'all-mappings-panel';
+
+/**
+ * Append the "All Mappings" entry tile to the root view, styled like the other
+ * top-level folder cards. Idempotent: removes any prior copy first so repeated
+ * updateDashboard calls don't stack duplicates.
+ */
+function appendAllMappingsEntry(): void {
+  document.getElementById(ALL_MAPPINGS_ENTRY_ID)?.remove();
+
+  const tile = document.createElement('div');
+  tile.classList.add('document-entry', 'folder-entry');
+  tile.setAttribute('id', ALL_MAPPINGS_ENTRY_ID);
+
+  const icon = document.createElement('img');
+  icon.classList.add('document-icon');
+  icon.src = './Cress-gh/assets/img/folder-icon.svg';
+
+  const name = document.createElement('div');
+  name.innerText = 'All Mappings';
+
+  tile.appendChild(icon);
+  tile.appendChild(name);
+  tile.addEventListener('dblclick', openAllMappings, false);
+
+  documentsContainer.appendChild(tile);
+}
+
+/**
+ * Show the view-all panel over the dashboard. Builds the panel lazily on first
+ * open, then repopulates it each time so the list reflects the latest login /
+ * remote state.
+ */
+async function openAllMappings(): Promise<void> {
+  let panel = document.getElementById(ALL_MAPPINGS_PANEL_ID);
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.setAttribute('id', ALL_MAPPINGS_PANEL_ID);
+    // Sit on top of the normal dashboard content area.
+    backgroundArea.appendChild(panel);
+  }
+  panel.innerHTML = '';
+  panel.style.display = 'block';
+  // Hide the normal file grid while the panel is open.
+  documentsContainer.style.display = 'none';
+
+  // Header: Back + title
+  const header = document.createElement('div');
+  header.classList.add('all-mappings-header');
+
+  const back = document.createElement('button');
+  back.classList.add('all-mappings-back');
+  back.innerText = 'Back';
+  back.addEventListener('click', closeAllMappings);
+
+  const title = document.createElement('div');
+  title.classList.add('all-mappings-title');
+  title.innerText = 'All Mappings';
+
+  header.appendChild(back);
+  header.appendChild(title);
+  panel.appendChild(header);
+
+  const body = document.createElement('div');
+  body.classList.add('all-mappings-body');
+  panel.appendChild(body);
+
+  await populateAllMappings(body);
+}
+
+/** Hide the panel and restore the normal dashboard file grid. */
+function closeAllMappings(): void {
+  const panel = document.getElementById(ALL_MAPPINGS_PANEL_ID);
+  if (panel) panel.style.display = 'none';
+  documentsContainer.style.display = '';
+}
+
+/**
+ * Fill the panel body: the current user's own files (editable) up top, then a
+ * row per foreign user that expands in place. Failures degrade to a message
+ * rather than throwing, so a missing index / logged-out state just shows less.
+ */
+async function populateAllMappings(body: HTMLElement): Promise<void> {
+  const loading = document.createElement('div');
+  loading.classList.add('all-mappings-hint');
+  loading.innerText = 'Loading…';
+  body.appendChild(loading);
+
+  let foreignUsers: string[] = [];
+  try {
+    foreignUsers = await listIndexedForeignUsers();
+  } catch (err) {
+    console.error('listIndexedForeignUsers failed:', err);
+  }
+
+  loading.remove();
+
+  // Section: your own files (editable), pulled from the FileSystem root so it
+  // matches exactly what "My Mappings" shows.
+  const ownHint = document.createElement('div');
+  ownHint.classList.add('all-mappings-hint');
+  ownHint.innerText = 'Your files — click any file to open and edit.';
+  body.appendChild(ownHint);
+
+  const ownGrid = document.createElement('div');
+  ownGrid.classList.add('all-mappings-grid');
+  body.appendChild(ownGrid);
+  renderOwnFilesInto(ownGrid);
+
+  // Section: other people's mappings.
+  const foreignHint = document.createElement('div');
+  foreignHint.classList.add('all-mappings-hint');
+  foreignHint.innerText = foreignUsers.length
+    ? "Other people's mappings — open a user to view (read only):"
+    : 'No other users found.';
+  body.appendChild(foreignHint);
+
+  foreignUsers.forEach((user) => body.appendChild(createForeignUserRow(user)));
+}
+
+/**
+ * Render the current user's own files as normal editable tiles into a grid.
+ * Reads the FileSystem root's file children directly (same source as the main
+ * dashboard) so behaviour and appearance match "My Mappings".
+ */
+function renderOwnFilesInto(grid: HTMLElement): void {
+  const root = state.getFolderPath().at(0);
+  if (!root) return;
+  root.children
+    .filter((entry: IEntry) => entry.type === EntryType.File)
+    .forEach((entry: IEntry) => {
+      const tile = createTile(entry);
+      // In the panel we don't want drag/selection semantics; a double-click to
+      // open is enough and matches My Mappings.
+      tile.setAttribute('draggable', 'false');
+      tile.addEventListener('dblclick', () => openFile(entry as IFile), false);
+      grid.appendChild(tile);
+    });
+}
+
+/**
+ * A collapsible row for one foreign user. Collapsed by default; expanding it
+ * lazily fetches that user's files and renders them as read-only tiles. This is
+ * pure show/hide — no navigation state changes.
+ */
+function createForeignUserRow(user: string): HTMLElement {
+  const row = document.createElement('div');
+  row.classList.add('foreign-user-row');
+
+  const header = document.createElement('div');
+  header.classList.add('foreign-user-header');
+
+  const chevron = document.createElement('span');
+  chevron.classList.add('foreign-user-chevron');
+  chevron.innerText = '▸';
+
+  const label = document.createElement('span');
+  label.classList.add('foreign-user-name');
+  label.innerText = user;
+
+  header.appendChild(chevron);
+  header.appendChild(label);
+  row.appendChild(header);
+
+  const filesWrap = document.createElement('div');
+  filesWrap.classList.add('foreign-user-files');
+  filesWrap.style.display = 'none';
+  row.appendChild(filesWrap);
+
+  let loaded = false;
+  header.addEventListener('click', async () => {
+    const isOpen = filesWrap.style.display !== 'none';
+    if (isOpen) {
+      filesWrap.style.display = 'none';
+      chevron.innerText = '▸';
+      return;
+    }
+    filesWrap.style.display = 'block';
+    chevron.innerText = '▾';
+    if (!loaded) {
+      loaded = true;
+      await loadForeignUserFiles(user, filesWrap);
+    }
+  });
+
+  return row;
+}
+
+/** Fetch and render one user's files as read-only tiles. */
+async function loadForeignUserFiles(
+  user: string,
+  wrap: HTMLElement,
+): Promise<void> {
+  wrap.innerHTML = '';
+  const loading = document.createElement('div');
+  loading.classList.add('all-mappings-hint');
+  loading.innerText = 'Loading…';
+  wrap.appendChild(loading);
+
+  let files: { path: string }[] = [];
+  try {
+    files = await getMappingStorage().listForeignMappings(user);
+  } catch (err) {
+    console.error(`listForeignMappings failed for "${user}":`, err);
+  }
+
+  loading.remove();
+
+  if (!files.length) {
+    const empty = document.createElement('div');
+    empty.classList.add('all-mappings-hint');
+    empty.innerText = 'No files.';
+    wrap.appendChild(empty);
+    return;
+  }
+
+  const grid = document.createElement('div');
+  grid.classList.add('all-mappings-grid');
+  files.forEach((meta) => grid.appendChild(createForeignTile(user, meta.path)));
+  wrap.appendChild(grid);
+}
+
+/**
+ * A read-only tile for a foreign file: white card like your own files (open but
+ * not edit — never greyed out), plus a "Copy to my mappings" action.
+ * Deliberately has no drag / selection / context-menu behaviour — foreign files
+ * are not entries in the FileSystem tree. Read-only is conveyed by context (the
+ * file sits inside another user's row, and only offers a copy action), matching
+ * how Drive/Finder present others' files without a per-file badge.
+ */
+function createForeignTile(owner: string, path: string): HTMLElement {
+  const tile = document.createElement('div');
+  tile.classList.add('document-entry', 'file-entry', 'foreign-tile');
+  tile.setAttribute('draggable', 'false');
+
+  const icon = document.createElement('img');
+  icon.classList.add('document-icon');
+  icon.src = './Cress-gh/assets/img/folio-icon.svg';
+
+  const name = document.createElement('div');
+  name.classList.add('foreign-tile-name');
+  name.innerText = path;
+
+  const copyBtn = document.createElement('button');
+  copyBtn.classList.add('foreign-tile-copy');
+  copyBtn.innerText = 'Copy to my mappings';
+  copyBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    void handleCopyForeign(owner, path);
+  });
+
+  tile.appendChild(icon);
+  tile.appendChild(name);
+  tile.appendChild(copyBtn);
+
+  return tile;
+}
+
+/**
+ * Copy a foreign mapping into the current user's own storage. On a same-name
+ * clash the storage layer throws ConflictError; we then offer the Finder-style
+ * choice (Replace / Keep both / Cancel). Keep both re-issues the copy with a
+ * suggested new name; Replace uses the dedicated overwrite path.
+ */
+async function handleCopyForeign(owner: string, path: string): Promise<void> {
+  const storage = getMappingStorage();
+  try {
+    await storage.copyForeignMapping(owner, path);
+    refreshAllMappingsOwnFiles();
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      showCopyConflictDialog(owner, path);
+      return;
+    }
+    console.error(`copyForeignMapping failed for "${owner}/${path}":`, err);
+    window.alert(`Could not copy "${path}".`);
+  }
+}
+
+/** Suggest a non-colliding name, e.g. "foo" -> "foo copy". */
+function suggestCopyName(path: string): string {
+  return `${path} copy`;
+}
+
+/**
+ * Finder-style same-name conflict dialog: Replace / Keep both / Cancel. Built
+ * as a lightweight self-contained overlay rather than going through the
+ * enum-based ModalWindow (which binds fixed views to fixed template HTML).
+ */
+function showCopyConflictDialog(owner: string, path: string): void {
+  const overlay = document.createElement('div');
+  overlay.classList.add('copy-conflict-overlay');
+
+  const box = document.createElement('div');
+  box.classList.add('copy-conflict-box');
+
+  const msg = document.createElement('div');
+  msg.classList.add('copy-conflict-msg');
+  msg.innerText = `You already have a mapping named "${path}". What would you like to do?`;
+  box.appendChild(msg);
+
+  const actions = document.createElement('div');
+  actions.classList.add('copy-conflict-actions');
+
+  const close = () => overlay.remove();
+
+  const replaceBtn = document.createElement('button');
+  replaceBtn.innerText = 'Replace';
+  replaceBtn.addEventListener('click', async () => {
+    close();
+    try {
+      await getMappingStorage().copyForeignMappingReplacing(owner, path);
+      refreshAllMappingsOwnFiles();
+    } catch (err) {
+      console.error('Replace copy failed:', err);
+      window.alert(`Could not replace "${path}".`);
+    }
+  });
+
+  const keepBothBtn = document.createElement('button');
+  keepBothBtn.innerText = 'Keep both';
+  keepBothBtn.addEventListener('click', async () => {
+    close();
+    const newName = suggestCopyName(path);
+    try {
+      await getMappingStorage().copyForeignMapping(owner, path, newName);
+      refreshAllMappingsOwnFiles();
+    } catch (err) {
+      if (err instanceof ConflictError) {
+        // The suggested name also exists; let the user try again.
+        showCopyConflictDialog(owner, path);
+        return;
+      }
+      console.error('Keep-both copy failed:', err);
+      window.alert(`Could not copy "${path}".`);
+    }
+  });
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.innerText = 'Cancel';
+  cancelBtn.addEventListener('click', close);
+
+  actions.appendChild(replaceBtn);
+  actions.appendChild(keepBothBtn);
+  actions.appendChild(cancelBtn);
+  box.appendChild(actions);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+}
+
+/**
+ * A copied file lands in the user's own GitHub/local storage, which is a
+ * different source of truth from the FileSystem tree the dashboard renders, so
+ * the copy won't appear in the panel's "your files" section without a refresh.
+ * For now we just re-render that section's grid from the current tree; a full
+ * reconciliation of remote-only files into the tree is a separate concern.
+ */
+function refreshAllMappingsOwnFiles(): void {
+  const panel = document.getElementById(ALL_MAPPINGS_PANEL_ID);
+  if (!panel) return;
+  const grid = panel.querySelector('.all-mappings-grid');
+  if (grid instanceof HTMLElement) {
+    grid.innerHTML = '';
+    renderOwnFilesInto(grid);
+  }
+}

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -5,7 +5,12 @@ import {
   FileSystemTools,
   EntryType,
 } from './FileSystem';
-import { deleteDocument, updateDocName, addDocument } from './Storage';
+import {
+  deleteDocument,
+  updateDocName,
+  addDocument,
+  updateAttachment,
+} from './Storage';
 import { FileSystemManager } from './FileSystem';
 import { ShiftSelectionManager, dashboardState } from './DashboardTools';
 import { InitUploadArea } from './UploadArea';
@@ -2170,7 +2175,10 @@ function createForeignTile(owner: string, path: string): HTMLElement {
 async function handleCopyForeign(owner: string, path: string): Promise<void> {
   const storage = getMappingStorage();
   try {
-    await storage.copyForeignMapping(owner, path);
+    const outcome = await storage.copyForeignMapping(owner, path);
+    if (outcome.status !== 'conflict') {
+      await materializeCopyInTree(outcome.path);
+    }
     refreshAllMappingsOwnFiles();
   } catch (err) {
     if (err instanceof ConflictError) {
@@ -2214,7 +2222,13 @@ function showCopyConflictDialog(owner: string, path: string): void {
   replaceBtn.addEventListener('click', async () => {
     close();
     try {
-      await getMappingStorage().copyForeignMappingReplacing(owner, path);
+      const outcome = await getMappingStorage().copyForeignMappingReplacing(
+        owner,
+        path,
+      );
+      if (outcome.status !== 'conflict') {
+        await materializeCopyInTree(outcome.path);
+      }
       refreshAllMappingsOwnFiles();
     } catch (err) {
       console.error('Replace copy failed:', err);
@@ -2228,7 +2242,14 @@ function showCopyConflictDialog(owner: string, path: string): void {
     close();
     const newName = suggestCopyName(path);
     try {
-      await getMappingStorage().copyForeignMapping(owner, path, newName);
+      const outcome = await getMappingStorage().copyForeignMapping(
+        owner,
+        path,
+        newName,
+      );
+      if (outcome.status !== 'conflict') {
+        await materializeCopyInTree(outcome.path);
+      }
       refreshAllMappingsOwnFiles();
     } catch (err) {
       if (err instanceof ConflictError) {
@@ -2251,6 +2272,72 @@ function showCopyConflictDialog(owner: string, path: string): void {
   box.appendChild(actions);
   overlay.appendChild(box);
   document.body.appendChild(overlay);
+}
+
+/**
+ * Materialize a just-copied mapping as a real FileSystem tree node so it appears
+ * in "Your files" / My Mappings and opens in the editor.
+ *
+ * Copying writes GitHub (source of truth) plus a name-keyed local mirror via
+ * MappingStorage, but the dashboard renders UUID-keyed canonical docs from the
+ * FileSystem tree (see handleAddFile -> addDocument). Without this step a copy
+ * lands on GitHub yet never shows up in the tree. Here we pull the copied
+ * content back (remote-first via loadMapping), convert csv.ts's positional
+ * string grid into Cress's canonical [headers, ...rowObjects] attachment shape
+ * (identical to createJson()'s output, so a copied file reads exactly like an
+ * uploaded one), then either update an existing same-named node in place
+ * (Replace, or an idempotent re-copy) or create a fresh UUID doc + tree node.
+ *
+ * Added to the FileSystem ROOT because renderOwnFilesInto / My Mappings read
+ * root's file children; a copy dropped into some nested nav folder would not
+ * surface in the panel.
+ */
+async function materializeCopyInTree(destName: string): Promise<void> {
+  const root = state.getFolderPath().at(0);
+  if (!root) return;
+
+  // Copied content as a 2D string grid (row 0 = headers). loadMapping is
+  // remote-first (a copy is always logged in) with the local mirror as fallback.
+  const grid = await getMappingStorage().loadMapping(destName);
+  if (!grid || grid.length === 0) return;
+
+  // csv.ts grid (string[][]) -> Storage.ts canonical shape:
+  // [ headerArray, ...{ [header]: value } ]. Build the row objects with an
+  // explicit loop (no Object.fromEntries) to stay lib-target agnostic.
+  const [headers, ...dataRows] = grid;
+  const data = dataRows.map((cells) => {
+    const obj: Record<string, string> = {};
+    headers.forEach((h, i) => {
+      obj[h] = cells[i] ?? '';
+    });
+    return obj;
+  });
+  const body = [headers, ...data];
+
+  // Reuse an existing same-named root node (Replace / identical re-copy): update
+  // its content in place so the node isn't duplicated and doesn't go stale.
+  const existing = root.children.find(
+    (e: IEntry) => e.type === EntryType.File && e.name === destName,
+  ) as IFile | undefined;
+
+  if (existing) {
+    await updateAttachment(existing.id, body);
+    updateDashboard();
+    return;
+  }
+
+  const id = uuidv4();
+  const blob = new Blob([JSON.stringify(body, null, 2)], {
+    type: 'application/json',
+  });
+  await addDocument(id, destName, blob);
+
+  const fileEntry = FileSystemTools.createFile(destName, id);
+  const docEntry = FileSystemTools.addMetadata(fileEntry, {
+    created_on: new Date().toLocaleString(),
+  });
+  FileSystemTools.addEntry(docEntry, root);
+  updateDashboard();
 }
 
 /**

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -6,6 +6,10 @@ import { InitUploadArea } from './UploadArea';
 import * as contextMenuContent from './ContextMenuContent';
 import { ModalWindow, ModalWindowView } from '../utils/ModalWindow';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  getMappingStorage,
+  nameToPath,
+} from './githubStorage/createMappingStorage';
 
 const documentsContainer: HTMLDivElement = document.querySelector(
   '#fs-content-container',
@@ -47,6 +51,9 @@ let metaKeyIsPressed = false;
 let shiftKeyIsPressed = false;
 let currentDragTarget = null;
 let rightClicked = false;
+
+const TRASH_SUFFIX =
+  / - \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} [APMapm]{2}$/;
 
 openButton?.addEventListener('click', openDocsHandler);
 removeButton?.addEventListener('click', removeDocsHandler);
@@ -396,15 +403,23 @@ function putBackDocsHandler() {
  * @param parentFolder
  * @returns
  */
-function deleteFileEntry(file: IFile, parentFolder: IFolder): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    deleteDocument(file.id)
-      .then(() => {
-        FileSystemTools.removeEntry(file, parentFolder);
-        resolve(true);
-      })
-      .catch(() => reject(false));
-  });
+
+async function deleteFileEntry(
+  file: IFile,
+  parentFolder: IFolder,
+): Promise<boolean> {
+  try {
+    // Trash appends " - <datetime>" on name collisions, but the remote file
+    // keeps its original name. Strip the suffix before resolving the GitHub path.
+    const remoteName = file.name.replace(TRASH_SUFFIX, '');
+    await getMappingStorage().deleteRemoteOnly(nameToPath(remoteName));
+    await deleteDocument(file.id);
+    FileSystemTools.removeEntry(file, parentFolder);
+    return true;
+  } catch (err) {
+    console.error('deleteFileEntry failed:', err);
+    return false;
+  }
 }
 
 /**

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -1884,52 +1884,92 @@ function appendAllMappingsEntry(): void {
 }
 
 /**
- * Show the view-all panel over the dashboard. Builds the panel lazily on first
- * open, then repopulates it each time so the list reflects the latest login /
- * remote state.
+ * Show the view-all panel over the dashboard. Reuses the dashboard's own Back
+ * button (#fs-back-btn) and breadcrumb (#nav-path-container) rather than drawing
+ * its own, so navigation looks identical to the rest of the app. The panel
+ * itself only renders the file lists. Built lazily on first open, then
+ * repopulated each time so the list reflects the latest login / remote state.
  */
 async function openAllMappings(): Promise<void> {
   let panel = document.getElementById(ALL_MAPPINGS_PANEL_ID);
   if (!panel) {
     panel = document.createElement('div');
     panel.setAttribute('id', ALL_MAPPINGS_PANEL_ID);
+    // Stop clicks inside the panel from bubbling to backgroundArea's click
+    // handler, which calls updateFSButtons() and would reset our borrowed Back
+    // button (leaving the user stranded with a disabled Back).
+    panel.addEventListener('click', (e) => e.stopPropagation());
     // Sit on top of the normal dashboard content area.
     backgroundArea.appendChild(panel);
   }
   panel.innerHTML = '';
   panel.style.display = 'block';
-  // Hide the normal file grid while the panel is open.
+  // Hide the normal file grid while the panel is open; keep the breadcrumb
+  // (#fs-top-zone) and Back button (#fs-middle-zone) visible and reuse them.
   documentsContainer.style.display = 'none';
 
-  // Header: Back + title
-  const header = document.createElement('div');
-  header.classList.add('all-mappings-header');
-
-  const back = document.createElement('button');
-  back.classList.add('all-mappings-back');
-  back.innerText = 'Back';
-  back.addEventListener('click', closeAllMappings);
-
-  const title = document.createElement('div');
-  title.classList.add('all-mappings-title');
-  title.innerText = 'All Mappings';
-
-  header.appendChild(back);
-  header.appendChild(title);
-  panel.appendChild(header);
+  // Extend the breadcrumb to read "Home / All Mappings" (folderPath is still
+  // [root] since we didn't navigate the tree).
+  const crumb = document.getElementById('nav-path-container');
+  if (crumb && !document.getElementById('all-mappings-crumb')) {
+    const sep = document.createElement('div');
+    sep.classList.add('nav-path-seperator');
+    sep.innerHTML = ' / ';
+    sep.setAttribute('id', 'all-mappings-crumb-sep');
+    const seg = document.createElement('div');
+    seg.classList.add('nav-path-section');
+    seg.setAttribute('id', 'all-mappings-crumb');
+    seg.innerText = 'All Mappings';
+    crumb.appendChild(sep);
+    crumb.appendChild(seg);
+  }
 
   const body = document.createElement('div');
   body.classList.add('all-mappings-body');
   panel.appendChild(body);
 
   await populateAllMappings(body);
+
+  // Activate the Back button LAST, after any rendering that might have rebuilt
+  // it, so nothing overwrites the active state. We keep the same node (no
+  // clone/replace) to avoid dangling the dashboard's own backButton reference.
+  activatePanelBackButton();
 }
 
-/** Hide the panel and restore the normal dashboard file grid. */
+/**
+ * Turn the dashboard's Back button into the panel's close control: active
+ * colour (opacity 100%, like entering Samples), clickable, and wired to
+ * closeAllMappings. Idempotent — safe to call repeatedly.
+ */
+function activatePanelBackButton(): void {
+  const back = document.getElementById('fs-back-btn') as HTMLButtonElement;
+  if (!back) return;
+  back.classList.add('active');
+  back.removeAttribute('disabled');
+  back.removeEventListener('click', closeAllMappings);
+  back.addEventListener('click', closeAllMappings);
+}
+
+/**
+ * Hide the panel and restore the normal dashboard: show the file grid again,
+ * strip the "All Mappings" breadcrumb segment, detach our Back listener, and
+ * rebuild the dashboard. updateDashboard -> updateBackButton fully owns the
+ * Back button's colour/disabled state afterwards (it disables + greys it at the
+ * root), so we must NOT set those here or we'd fight that logic.
+ */
 function closeAllMappings(): void {
   const panel = document.getElementById(ALL_MAPPINGS_PANEL_ID);
   if (panel) panel.style.display = 'none';
   documentsContainer.style.display = '';
+  document.getElementById('all-mappings-crumb-sep')?.remove();
+  document.getElementById('all-mappings-crumb')?.remove();
+
+  const back = document.getElementById('fs-back-btn') as HTMLButtonElement;
+  if (back) back.removeEventListener('click', closeAllMappings);
+
+  // Rebuild at the current (root) path; updateBackButton resets the Back button
+  // to its correct root state (disabled, grey) and re-appends the entry tile.
+  void updateDashboard(state.getFolderPath());
 }
 
 /**
@@ -2025,11 +2065,15 @@ function createForeignUserRow(user: string): HTMLElement {
   row.appendChild(filesWrap);
 
   let loaded = false;
-  header.addEventListener('click', async () => {
+  header.addEventListener('click', async (e) => {
+    // Stop the click bubbling to backgroundArea's handler, which calls
+    // updateFSButtons() and would reset our borrowed Back button.
+    e.stopPropagation();
     const isOpen = filesWrap.style.display !== 'none';
     if (isOpen) {
       filesWrap.style.display = 'none';
       chevron.innerText = '▸';
+      activatePanelBackButton();
       return;
     }
     filesWrap.style.display = 'block';
@@ -2038,6 +2082,10 @@ function createForeignUserRow(user: string): HTMLElement {
       loaded = true;
       await loadForeignUserFiles(user, filesWrap);
     }
+    // Re-assert the panel's Back state: rendering foreign tiles can trigger the
+    // dashboard to rebuild its Back button (dropping our active state + close
+    // listener), which would otherwise strand the user in the panel.
+    activatePanelBackButton();
   });
 
   return row;

--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -1,4 +1,10 @@
-import { IEntry, IFile, IFolder, FileSystemTools, EntryType } from './FileSystem';
+import {
+  IEntry,
+  IFile,
+  IFolder,
+  FileSystemTools,
+  EntryType,
+} from './FileSystem';
 import { deleteDocument, updateDocName, addDocument } from './Storage';
 import { FileSystemManager } from './FileSystem';
 import { ShiftSelectionManager, dashboardState } from './DashboardTools';

--- a/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
+++ b/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
@@ -75,7 +75,14 @@ export class GitHubUserRepoBackend implements StorageBackend {
   }
 
   private contentsUrl(path: string): string {
-    const { owner, repo } = this.deps;
+    return this.contentsUrlFor(this.deps.owner, path);
+  }
+
+  // owner-parameterized form of contentsUrl. Own-repo ops pass this.deps.owner
+  // (via contentsUrl above); cross-user reads pass another user's login. Repo
+  // name is shared (every user's mappings live in a repo of the same name).
+  private contentsUrlFor(owner: string, path: string): string {
+    const { repo } = this.deps;
     // Encode each path SEGMENT separately and rejoin with real '/'. A whole-path
     // encodeURIComponent() would turn the '/' in a subdir path (e.g.
     // ".trash/my-map.csv") into %2F, which the GitHub contents API treats as a
@@ -162,6 +169,38 @@ export class GitHubUserRepoBackend implements StorageBackend {
     return { content: fromBase64(json.content), sha: json.sha ?? null };
   }
 
+  /**
+   * Read a file from ANOTHER user's mappings repo (read-only, cross-user).
+   * Same shape as readFile but the owner is supplied by the caller instead of
+   * this.deps.owner. Used by the view-all / copy features: any logged-in user
+   * can read any user's PUBLIC cress-mappings repo with their own token. There
+   * is deliberately NO foreign write/delete -- "others' mappings are read-only"
+   * is enforced here by the absence of those methods, not just by GitHub's
+   * permission check at runtime.
+   */
+  async readForeignFile(
+    owner: string,
+    path: string,
+  ): Promise<ReadResult | null> {
+    const url = new URL(this.contentsUrlFor(owner, path));
+    if (this.deps.branch) url.searchParams.set('ref', this.deps.branch);
+    const res = await this.deps.fetch(url.toString(), {
+      headers: this.authHeaders(),
+    });
+
+    if (res.status === 404) return null;
+    if (!res.ok)
+      throw new Error(
+        `readForeignFile failed: ${res.status} ${await safeText(res)}`,
+      );
+
+    const json = (await res.json()) as { content?: string; sha?: string };
+    if (json.content === undefined) {
+      throw new Error(`readForeignFile: ${path} is not a file`);
+    }
+    return { content: fromBase64(json.content), sha: json.sha ?? null };
+  }
+
   async writeFile(
     path: string,
     content: string,
@@ -220,7 +259,33 @@ export class GitHubUserRepoBackend implements StorageBackend {
       .filter((e) => e.type === 'file' && e.name.endsWith(CSV_EXT))
       .map((e) => ({ path: stripCsv(e.name), sha: e.sha }));
   }
+  /**
+   * List the top-level mappings in ANOTHER user's repo (read-only, cross-user).
+   * Like listFiles but for a caller-supplied owner. Builds the directory URL
+   * directly (no trailing-segment regex) since there is no path to encode.
+   */
+  async listForeignFiles(owner: string): Promise<StoredFileMeta[]> {
+    const { repo } = this.deps;
+    const url = new URL(`${this.base}/repos/${owner}/${repo}/contents`);
+    if (this.deps.branch) url.searchParams.set('ref', this.deps.branch);
+    const res = await this.deps.fetch(url.toString(), {
+      headers: this.authHeaders(),
+    });
+    if (res.status === 404) return [];
+    if (!res.ok)
+      throw new Error(
+        `listForeignFiles failed: ${res.status} ${await safeText(res)}`,
+      );
 
+    const json = (await res.json()) as Array<{
+      name: string;
+      sha: string;
+      type: string;
+    }>;
+    return json
+      .filter((e) => e.type === 'file' && e.name.endsWith(CSV_EXT))
+      .map((e) => ({ path: stripCsv(e.name), sha: e.sha }));
+  }
   async deleteFile(path: string, sha: string): Promise<void> {
     const body: Record<string, unknown> = {
       message: `cress: delete ${withCsv(path)}`,

--- a/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
+++ b/src/Dashboard/githubStorage/GitHubUserRepoBackend.ts
@@ -76,7 +76,18 @@ export class GitHubUserRepoBackend implements StorageBackend {
 
   private contentsUrl(path: string): string {
     const { owner, repo } = this.deps;
-    return `${this.base}/repos/${owner}/${repo}/contents/${encodeURIComponent(withCsv(path))}`;
+    // Encode each path SEGMENT separately and rejoin with real '/'. A whole-path
+    // encodeURIComponent() would turn the '/' in a subdir path (e.g.
+    // ".trash/my-map.csv") into %2F, which the GitHub contents API treats as a
+    // literal filename char rather than a directory separator -- creating a
+    // root-level file literally named ".trash/my-map.csv" instead of a file
+    // inside the .trash dir. Per-segment encoding keeps separators intact while
+    // still escaping spaces/unicode within each segment.
+    const encoded = withCsv(path)
+      .split('/')
+      .map((seg) => encodeURIComponent(seg))
+      .join('/');
+    return `${this.base}/repos/${owner}/${repo}/contents/${encoded}`;
   }
 
   /** True if the target repo already exists for this user (GET /repos/:owner/:repo). */

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -221,6 +221,76 @@ export class MappingStorage {
     return this.saveMapping(destPath, rows);
   }
 
+  /**
+   * Copy a foreign mapping, overwriting the current user's OWN same-named file
+   * if one exists. This is the "Replace" branch of the same-name dialog:
+   * copyForeignMapping throws ConflictError on a name clash and leaves the
+   * decision to the caller; this method is what the caller invokes once the
+   * user has chosen to replace.
+   *
+   * Only ever writes the current user's own repo -- the foreign source is read
+   * through ForeignReader (which has no write methods), so "replace" can never
+   * touch anyone else's file, only the caller's own destination. The overwrite
+   * follows resolveConflictKeepLocal's shape: re-read the destination's current
+   * sha, then write past it so the PUT is accepted regardless of the (possibly
+   * empty) sha cache.
+   */
+  async copyForeignMappingReplacing(
+    fromOwner: string,
+    path: string,
+    newName?: string,
+  ): Promise<SaveOutcome> {
+    const reader = this.deps.foreignReader;
+    if (!reader) {
+      throw new Error(
+        'copyForeignMappingReplacing: no foreignReader configured',
+      );
+    }
+    if (!this.isLoggedIn()) {
+      throw new NotAuthenticatedError(
+        'copyForeignMappingReplacing requires login',
+      );
+    }
+
+    const src = await reader.readForeignFile(fromOwner, path);
+    if (!src) {
+      throw new Error(
+        `copyForeignMappingReplacing: "${path}" not found in ${fromOwner}'s mappings`,
+      );
+    }
+
+    const rows = csvToRows(src.content); // parse = validation gate
+    const destPath = newName ?? path;
+    const csv = rowsToCsv(rows);
+
+    // Re-read the destination's current sha so the overwrite PUT is accepted
+    // even when this session never touched the file (empty shaCache). Mirrors
+    // resolveConflictKeepLocal: current sha may be null (destination absent),
+    // which writeFile treats as a create.
+    const current = await this.deps.backend.readFile(destPath);
+    const { sha } = await this.deps.backend.writeFile(
+      destPath,
+      csv,
+      current?.sha ?? null,
+    );
+    this.shaCache.set(destPath, sha);
+    await this.deps.local.set(destPath, csv);
+    return { status: 'saved-remote', path: destPath, sha };
+  }
+
+  /**
+   * List another user's mappings for the view-all UI. Thin passthrough to the
+   * ForeignReader so callers depend only on MappingStorage, never on the
+   * backend directly. Returns [] when no foreignReader is configured (e.g.
+   * Worker wiring), so the UI can render "nothing foreign" without special-
+   * casing.
+   */
+  async listForeignMappings(owner: string): Promise<StoredFileMeta[]> {
+    const reader = this.deps.foreignReader;
+    if (!reader) return [];
+    return reader.listForeignFiles(owner);
+  }
+
   async deleteMapping(path: string): Promise<void> {
     await this.deps.local.remove(path);
     await this.trashRemote(path);

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -1,4 +1,4 @@
-// storage.ts
+// MappingStorage.ts
 // The common orchestration layer. Talks ONLY to StorageBackend + the CSV pure
 // functions, so it is identical whether the backend is Option 1 (Worker) or
 // Option 2 (user repo). This is the "doesn't get thrown away" core.
@@ -7,7 +7,7 @@
 //   - turn Cress table rows into CSV and back (delegates to csv.ts)
 //   - remember the last-seen SHA per file so updates are conflict-checked
 //   - when not logged in, fall back to a local store (PouchDB in Cress; an
-//     in-memory map in this prototype) so the app still works offline (#138).
+//     in-memory map in this prototype) so the app still works offline.
 
 import { rowsToCsv, csvToRows, CsvRow } from './csv';
 import {
@@ -33,6 +33,14 @@ export interface MappingStorageDeps {
   getToken: () => string | null;
 }
 
+/**
+ * Subdir prefix for soft-deleted mappings on the remote. A trashed file lives
+ * at `${TRASH_PREFIX}<path>` (the backend adds .csv at its own boundary, giving
+ * e.g. `.trash/my-map.csv`), so it no longer appears among the top-level
+ * mappings yet stays recoverable.
+ */
+const TRASH_PREFIX = '.trash/';
+
 export type SaveOutcome =
   | { status: 'saved-remote'; path: string; sha: string }
   | { status: 'saved-local'; path: string } // logged out -> local only
@@ -52,7 +60,7 @@ export class MappingStorage {
   async saveMapping(path: string, rows: CsvRow[]): Promise<SaveOutcome> {
     const csv = rowsToCsv(rows);
 
-    // Logged-out fallback: keep working against the local store only (#138).
+    // Logged-out fallback: keep working against the local store only.
     if (!this.isLoggedIn()) {
       await this.deps.local.set(path, csv);
       return { status: 'saved-local', path };
@@ -131,20 +139,85 @@ export class MappingStorage {
 
   async deleteMapping(path: string): Promise<void> {
     await this.deps.local.remove(path);
-    await this.deleteRemoteOnly(path);
+    await this.trashRemote(path);
   }
 
-  async deleteRemoteOnly(path: string): Promise<void> {
-    if (!this.isLoggedIn()) return;
-    let sha = this.shaCache.get(path);
-    if (!sha) {
-      const remote = await this.deps.backend.readFile(path);
-      sha = remote?.sha ?? undefined;
+  /**
+   * Soft-delete on the remote: move the file under TRASH_PREFIX instead of
+   * deleting, so it stays recoverable. GitHub has no
+   * rename, so the move is copy-then-delete via existing backend ops -- the
+   * StorageBackend interface is unchanged, so the Worker backend inherits this.
+   * No-op when logged out or when the source isn't on the remote.
+   */
+  async trashRemote(path: string): Promise<void> {
+    if (this.isLoggedIn()) {
+      await this.moveRemote(path, this.trashPathFor(path));
     }
-    if (sha) {
-      await this.deps.backend.deleteFile(path, sha);
-      this.shaCache.delete(path);
+  }
+
+  /**
+   * Reverse of trashRemote: move the file back out of TRASH_PREFIX to its
+   * original path. Used by Put Back. No-op when logged out or when the trashed
+   * copy is absent.
+   */
+  async restoreRemote(path: string): Promise<void> {
+    if (this.isLoggedIn()) {
+      await this.moveRemote(this.trashPathFor(path), path);
     }
+  }
+
+  /** TRASH_PREFIX-qualified path for a bare mapping path. Idempotent: never
+   *  double-prefixes. */
+  private trashPathFor(path: string): string {
+    return path.startsWith(TRASH_PREFIX) ? path : `${TRASH_PREFIX}${path}`;
+  }
+
+  /**
+   * Move a remote file from->to by copy-then-delete, since GitHub's contents
+   * API has no atomic rename. Reads the source (for its content + delete SHA),
+   * writes it at the destination (probing the destination's SHA first so an
+   * already-occupied path updates instead of failing the create), then deletes
+   * the source. No-op if the source doesn't exist, so callers don't special-
+   * case local-only files. shaCache is kept in step: destination SHA recorded,
+   * source entry dropped.
+   *
+   * NOT atomic. If the process dies between write and delete you get the file
+   * at BOTH paths; a subsequent same-direction move self-heals. Acceptable for
+   * single-user trash; revisit if concurrent movers appear.
+   */
+  private async moveRemote(from: string, to: string): Promise<void> {
+    const src = await this.deps.backend.readFile(from);
+    if (!src) return; // nothing at source -> nothing to move
+
+    // The destination may already be occupied -- e.g. the user re-saved the
+    // file (recreating the top-level copy) before pressing Put Back. A bare
+    // create (sha=null) would then 422, the error would be swallowed by the
+    // caller's .catch, and the source would never be deleted (file stuck at
+    // BOTH paths). So probe the destination first:
+    const dest = await this.deps.backend.readFile(to);
+    if (dest && dest.content !== src.content) {
+      // Same path, DIFFERENT content: almost certainly a same-named file.
+      // Do NOT silently clobber it -- surface a conflict for the caller to
+      // handle. (Same-name collisions are a known limitation of name-as-key
+      // storage; the real fix is uuid keys.)
+      throw new ConflictError(
+        `moveRemote: destination "${to}" exists with different content`,
+        to,
+      );
+    }
+    // dest absent -> create (null); dest present with same content -> overwrite
+    // using its sha (idempotent, self-healing if a prior move half-completed).
+    const { sha: newSha } = await this.deps.backend.writeFile(
+      to,
+      src.content,
+      dest?.sha ?? null,
+    );
+    this.shaCache.set(to, newSha);
+
+    if (src.sha) {
+      await this.deps.backend.deleteFile(from, src.sha);
+    }
+    this.shaCache.delete(from);
   }
 }
 

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -26,11 +26,29 @@ export interface LocalStore {
   remove(path: string): Promise<void>;
 }
 
+/**
+ * Read-only view of ANOTHER user's mappings. Deliberately has no write or
+ * delete methods: "foreign files are read-only" is enforced at compile time
+ * by the missing methods, not by relying on GitHub's runtime 403.
+ * GitHubUserRepoBackend implements this; the Worker backend does not, so
+ * wiring that omits `foreignReader` simply has no copy feature.
+ */
+export interface ForeignReader {
+  readForeignFile(
+    owner: string,
+    path: string,
+  ): Promise<{ content: string; sha: string } | null>;
+  listForeignFiles(owner: string): Promise<StoredFileMeta[]>;
+}
+
 export interface MappingStorageDeps {
   backend: StorageBackend;
   local: LocalStore;
   /** Returns the current token, or null if logged out. Wraps getGithubToken(). */
   getToken: () => string | null;
+  /** Optional read-only access to other users' mappings. When absent, the
+   *  copy-foreign feature is unavailable (e.g. Worker backend wiring). */
+  foreignReader?: ForeignReader;
 }
 
 /**
@@ -135,6 +153,72 @@ export class MappingStorage {
     remote.forEach((m) => this.shaCache.set(m.path, m.sha ?? ''));
     const set = new Set<string>([...localNames, ...remote.map((m) => m.path)]);
     return [...set].sort();
+  }
+
+  /**
+   * Copy another user's mapping into the current user's own storage.
+   * Read foreign -> parse (csvToRows doubles as a bad-file gate) -> same-name
+   * check -> saveMapping through the single write path (sha cache + local
+   * mirror come for free).
+   *
+   * Same-name handling (Finder/Windows model, matching moveRemote):
+   *   - destination exists with SAME content -> idempotent no-op, returns the
+   *     existing state as 'saved-remote'.
+   *   - destination exists with DIFFERENT content -> throw ConflictError; the
+   *     UI decides (replace / rename / cancel). "Keep both" is the UI calling
+   *     again with `newName`.
+   * Equality is compared on normalized csv (rowsToCsv(csvToRows(x))) so
+   * hand-edited-but-equivalent files still count as identical.
+   *
+   * Authz note: read source repo + write own repo passes GitHub-native
+   * permissions with zero Worker involvement.
+   */
+  async copyForeignMapping(
+    fromOwner: string,
+    path: string,
+    newName?: string,
+  ): Promise<SaveOutcome> {
+    const reader = this.deps.foreignReader;
+    if (!reader) {
+      throw new Error('copyForeignMapping: no foreignReader configured');
+    }
+    if (!this.isLoggedIn()) {
+      // Reading a foreign repo needs a token, and the copy must land in the
+      // user's own remote repo; a local-only copy of someone else's file has
+      // no meaning here.
+      throw new NotAuthenticatedError('copyForeignMapping requires login');
+    }
+
+    const src = await reader.readForeignFile(fromOwner, path);
+    if (!src) {
+      throw new Error(
+        `copyForeignMapping: "${path}" not found in ${fromOwner}'s mappings`,
+      );
+    }
+
+    const rows = csvToRows(src.content); // parse = validation gate
+    const destPath = newName ?? path;
+    const normalized = rowsToCsv(rows);
+
+    // Explicit destination probe: shaCache is empty for files this session
+    // never touched, so a bare saveMapping could not tell "identical copy"
+    // apart from a real conflict.
+    const existing = await this.deps.backend.readFile(destPath);
+    if (existing) {
+      const existingNormalized = rowsToCsv(csvToRows(existing.content));
+      if (existingNormalized === normalized) {
+        // Already have an identical copy: refresh caches, done.
+        if (existing.sha) this.shaCache.set(destPath, existing.sha);
+        await this.deps.local.set(destPath, existing.content);
+        return { status: 'saved-remote', path: destPath, sha: existing.sha };
+      }
+      throw new ConflictError(
+        `copyForeignMapping: "${destPath}" exists with different content`,
+        destPath,
+      );
+    }
+
+    return this.saveMapping(destPath, rows);
   }
 
   async deleteMapping(path: string): Promise<void> {

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -156,6 +156,26 @@ export class MappingStorage {
   }
 
   /**
+   * List mapping names that exist on the REMOTE only (no local-mirror merge).
+   * Used by the dashboard's tree reconcile: the FileSystem tree must be
+   * compared against GitHub as the source of truth for existence, so
+   * local-only names (mirror orphans, unsynced docs) must not leak into this
+   * list the way they do in listMappings. Returns [] when logged out or when
+   * the backend reports NotAuthenticated, so callers can no-op silently.
+   */
+  async listRemoteMappings(): Promise<string[]> {
+    if (!this.isLoggedIn()) return [];
+    let remote: StoredFileMeta[] = [];
+    try {
+      remote = await this.deps.backend.listFiles();
+    } catch (err) {
+      if (!(err instanceof NotAuthenticatedError)) throw err;
+    }
+    remote.forEach((m) => this.shaCache.set(m.path, m.sha ?? ''));
+    return remote.map((m) => m.path).sort();
+  }
+
+  /**
    * Copy another user's mapping into the current user's own storage.
    * Read foreign -> parse (csvToRows doubles as a bad-file gate) -> same-name
    * check -> saveMapping through the single write path (sha cache + local

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -207,11 +207,30 @@ export class MappingStorage {
     }
     // dest absent -> create (null); dest present with same content -> overwrite
     // using its sha (idempotent, self-healing if a prior move half-completed).
-    const { sha: newSha } = await this.deps.backend.writeFile(
-      to,
-      src.content,
-      dest?.sha ?? null,
-    );
+    //
+    // Write with 409 retry. GitHub's contents API is eventually consistent: in
+    // rapid back-to-back moves, a destination path touched by the previous move
+    // can briefly report a stale sha, so a write that just probed it may 409.
+    // On conflict, wait (letting GitHub settle), re-probe the destination sha,
+    // and retry with backoff. A single move never enters the retry path (the
+    // loop breaks on first success).
+    let newSha = '';
+    let probeSha = dest?.sha ?? null;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        ({ sha: newSha } = await this.deps.backend.writeFile(
+          to,
+          src.content,
+          probeSha,
+        ));
+        break;
+      } catch (err) {
+        if (!(err instanceof ConflictError) || attempt >= 3) throw err;
+        await new Promise((r) => setTimeout(r, 200 * (attempt + 1)));
+        const reprobe = await this.deps.backend.readFile(to);
+        probeSha = reprobe?.sha ?? null;
+      }
+    }
     this.shaCache.set(to, newSha);
 
     if (src.sha) {

--- a/src/Dashboard/githubStorage/MappingStorage.ts
+++ b/src/Dashboard/githubStorage/MappingStorage.ts
@@ -131,8 +131,16 @@ export class MappingStorage {
 
   async deleteMapping(path: string): Promise<void> {
     await this.deps.local.remove(path);
+    await this.deleteRemoteOnly(path);
+  }
+
+  async deleteRemoteOnly(path: string): Promise<void> {
     if (!this.isLoggedIn()) return;
-    const sha = this.shaCache.get(path);
+    let sha = this.shaCache.get(path);
+    if (!sha) {
+      const remote = await this.deps.backend.readFile(path);
+      sha = remote?.sha ?? undefined;
+    }
     if (sha) {
       await this.deps.backend.deleteFile(path, sha);
       this.shaCache.delete(path);

--- a/src/Dashboard/githubStorage/PouchDbLocalStore.ts
+++ b/src/Dashboard/githubStorage/PouchDbLocalStore.ts
@@ -1,7 +1,7 @@
 // PouchDbLocalStore.ts
 // Adapter that implements the LocalStore interface (from MappingStorage.ts) on
 // top of Cress's existing PouchDB layer in ../Storage.ts. This is the
-// logged-out / offline fallback store (#138): Storage.ts itself is NOT changed,
+// logged-out / offline fallback store: Storage.ts itself is NOT changed,
 // we only call its existing exported functions.
 //
 // Two seams that were previously TODO are now resolved against the real

--- a/src/Dashboard/githubStorage/WorkerBackend.ts
+++ b/src/Dashboard/githubStorage/WorkerBackend.ts
@@ -26,8 +26,8 @@
 //
 // STATUS: frontend side is complete and mock-tested. The Worker endpoints above
 // do NOT exist yet -- the current Worker only does OAuth token exchange. Wiring
-// this end-to-end requires extending the Worker, which is deferred until the
-// meeting confirms Option 1 is the chosen direction.
+// this end-to-end requires extending the Worker, which is deferred until
+// Option 1 is confirmed as the chosen direction.
 
 import {
   StorageBackend,

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -77,6 +77,10 @@ export function getMappingStorage(): MappingStorage {
     backend: _backend,
     local: new PouchDbLocalStore(),
     getToken,
+    // The GitHub backend doubles as the read-only foreign reader (it already
+    // implements readForeignFile/listForeignFiles). Worker wiring would omit
+    // this line: no foreignReader, no copy feature.
+    foreignReader: _backend,
   });
   return _instance;
 }

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -1,5 +1,5 @@
 // createMappingStorage.ts
-// App-wiring assembly point for #3. The barrel (index.ts) only exports classes;
+// App-wiring assembly point. The barrel (index.ts) only exports classes;
 // this is where they are composed into a ready-to-use MappingStorage instance.
 //
 // Importing this file from an entry (editor.ts) is what finally pulls the whole
@@ -17,7 +17,7 @@
 import { MappingStorage } from './MappingStorage';
 import { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
 import { PouchDbLocalStore } from './PouchDbLocalStore';
-// Option 1 (Worker) -- swap in at the assembly line below if the meeting picks it.
+// Option 1 (Worker) -- swap in at the assembly line below if chosen.
 // import { WorkerBackend } from './WorkerBackend';
 
 const TOKEN_KEY = 'cress_github_token';

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -17,6 +17,7 @@
 import { MappingStorage } from './MappingStorage';
 import { GitHubUserRepoBackend } from './GitHubUserRepoBackend';
 import { PouchDbLocalStore } from './PouchDbLocalStore';
+import { fetchIndexedUsers } from './mappingsIndex';
 // Option 1 (Worker) -- swap in at the assembly line below if chosen.
 // import { WorkerBackend } from './WorkerBackend';
 
@@ -108,4 +109,25 @@ export async function ensureReady(): Promise<void> {
 export function resetMappingStorage(): void {
   _instance = null;
   _backend = null;
+}
+
+// Central index host during testing (personal account; see mappingsIndex.ts
+// for the ownership caveat and long-term plan).
+const INDEX_OWNER = 'kyuchia';
+
+/**
+ * Usernames known to the mappings index, excluding the logged-in user (their
+ * own files come from listMappings, not the foreign path). Empty when logged
+ * out or when the index is unreachable, so callers can render "no foreign
+ * users" without special-casing.
+ */
+export async function listIndexedForeignUsers(): Promise<string[]> {
+  if (!getToken()) return [];
+  const users = await fetchIndexedUsers({
+    fetch: window.fetch.bind(window),
+    getToken,
+    indexOwner: INDEX_OWNER,
+  });
+  const self = getOwner();
+  return users.filter((u) => u !== self);
 }

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -111,9 +111,11 @@ export function resetMappingStorage(): void {
   _backend = null;
 }
 
-// Central index host during testing (personal account; see mappingsIndex.ts
-// for the ownership caveat and long-term plan).
-const INDEX_OWNER = 'kyuchia';
+// Owner of the central mappings index repo (users.csv), held by the lab
+// service account since the August 2026 migration. The old personal-account
+// path still redirects, but that redirect is not permanent — keep this in
+// sync with the repo's real owner.
+const INDEX_OWNER = 'ddmaladmin';
 
 /**
  * Usernames known to the mappings index, excluding the logged-in user (their

--- a/src/Dashboard/githubStorage/mappingsIndex.ts
+++ b/src/Dashboard/githubStorage/mappingsIndex.ts
@@ -1,0 +1,65 @@
+// mappingsIndex.ts
+// Reads the central user-discovery index: a public repo (cress-mappings-index)
+// holding users.csv, one GitHub username per line. View-all resolves "which
+// users exist" by reading this list, then calls listForeignFiles per user.
+//
+// TEMPORARY OWNERSHIP: during testing the index lives under a personal account
+// and is curated by hand. Self-registration is deliberately avoided: it would
+// require cross-user writes to a shared repo, reintroducing the authz problem
+// the per-user-repo design removed. Long-term the index moves to the lab org
+// or is replaced by an automatic registration mechanism (see PR description).
+//
+// Deliberately NOT part of StorageBackend / ForeignReader: those are scoped to
+// mappings repos. The index is a different repo with a different lifecycle, so
+// it gets its own thin reader.
+
+import { NotAuthenticatedError } from './backend';
+
+export interface MappingsIndexDeps {
+  fetch: typeof fetch;
+  getToken: () => string | null;
+  /** Account that hosts the index repo (personal during testing). */
+  indexOwner: string;
+  indexRepo?: string; // default "cress-mappings-index"
+  apiBase?: string; // default "https://api.github.com"
+}
+
+const INDEX_FILE = 'users.csv';
+
+/**
+ * Fetch the list of usernames from the index. Lines are trimmed; empty lines
+ * and #-comment lines are skipped. Returns [] when the index repo or file is
+ * missing, so view-all degrades to showing nothing foreign instead of
+ * breaking.
+ *
+ * Uses the raw media type so the response body is the plain file content (no
+ * base64 decoding step).
+ */
+export async function fetchIndexedUsers(
+  deps: MappingsIndexDeps,
+): Promise<string[]> {
+  const token = deps.getToken();
+  if (!token) throw new NotAuthenticatedError();
+
+  const base = deps.apiBase ?? 'https://api.github.com';
+  const repo = deps.indexRepo ?? 'cress-mappings-index';
+  const url = `${base}/repos/${deps.indexOwner}/${repo}/contents/${INDEX_FILE}`;
+
+  const res = await deps.fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.raw+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (res.status === 404) return [];
+  if (!res.ok) {
+    throw new Error(`fetchIndexedUsers failed: ${res.status}`);
+  }
+
+  const text = await res.text();
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+}

--- a/src/Dashboard/githubStorage/mappingsIndex.ts
+++ b/src/Dashboard/githubStorage/mappingsIndex.ts
@@ -3,11 +3,11 @@
 // holding users.csv, one GitHub username per line. View-all resolves "which
 // users exist" by reading this list, then calls listForeignFiles per user.
 //
-// TEMPORARY OWNERSHIP: during testing the index lives under a personal account
-// and is curated by hand. Self-registration is deliberately avoided: it would
-// require cross-user writes to a shared repo, reintroducing the authz problem
-// the per-user-repo design removed. Long-term the index moves to the lab org
-// or is replaced by an automatic registration mechanism (see PR description).
+// OWNERSHIP: the index repo is held by the lab service account (see INDEX_OWNER
+// in createMappingStorage.ts) and is curated by hand. Self-registration is
+// deliberately avoided: it would require cross-user writes to a shared repo,
+// reintroducing the authz problem the per-user-repo design removed. Replacing
+// manual curation with an automatic registration mechanism remains open.
 //
 // Deliberately NOT part of StorageBackend / ForeignReader: those are scoped to
 // mappings repos. The index is a different repo with a different lifecycle, so
@@ -18,7 +18,7 @@ import { NotAuthenticatedError } from './backend';
 export interface MappingsIndexDeps {
   fetch: typeof fetch;
   getToken: () => string | null;
-  /** Account that hosts the index repo (personal during testing). */
+  /** Account that hosts the index repo. */
   indexOwner: string;
   indexRepo?: string; // default "cress-mappings-index"
   apiBase?: string; // default "https://api.github.com"


### PR DESCRIPTION
## Problem

"Your files" are rendered from a local PouchDB tree. Saves dual-write (GitHub + tree), but nothing ever rebuilds the tree *from* GitHub, so after clearing browser data or switching devices, the panel shows empty while the user's `cress-mappings` repo is intact. Pre-existing gap in the #140 storage layer, not a regression.

## Fix

Background reconcile on dashboard load, GitHub as source of truth: `listRemoteMappings()` (remote-only names, no-op when logged out) + `reconcileTreeWithRemote()`, paints the local tree first, then materializes any remote mapping not found anywhere in the tree (reuses `materializeCopyInTree`, idempotent).

**Additive-only for v1:** local-only entries are never deleted; no dirty/unsynced marker exists yet, so deletion could destroy an unsynced file. Deletion-side reconcile is a follow-up. Failures are non-fatal (console.warn, local tree stays usable).

## Testing (local, manual)

Fresh incognito + login → all repo files appear in ~1–2s (previously empty); editor content matches GitHub. Hard refresh → no duplicates. Saving new mappings and All Mappings unaffected. Logged out → silent no-op.

## Notes

Stacked on #145 (merge order: #140 → #141 → #145 → this); this PR's own commits are `6a003ad` + `eb09b09`. The `PouchDbLocalStore: 2 documents named ...` console message is the pre-existing mirror-orphan issue, unrelated.