### PR TITLE
fix: dashboard context menu (Open, Move to Trash, Put Back, Move error)

### DIFF
--- a/src/Dashboard/Dashboard.ts
+++ b/src/Dashboard/Dashboard.ts
@@ -371,7 +371,9 @@ function putBackDocsHandler() {
 
   for (let entry of selectedEntries) {
     const folderPathNames = entry.metadata['recover_folder'] as string[];
-    const targetFolder = state.getFolderPathByNames(folderPathNames);
+    const targetFolder = folderPathNames
+      ? state.getFolderPathByNames(folderPathNames)
+      : state.getFolderPath().at(0); // fallback: Home (e.g. trashed via drag, no recover_folder)
     if (targetFolder) {
       entry = FileSystemTools.removeMetadata(entry, [
         'removed_on',
@@ -1676,6 +1678,7 @@ function addSpecificContextMenuListeners(tile, index) {
 
     // select
     select(index);
+    updateActionBarButtons();
 
     showContextMenu(
       'selection-options',
@@ -1690,7 +1693,7 @@ function addSpecificContextMenuListeners(tile, index) {
   mainSection.addEventListener('click', (e) => {
     if (rightClicked) {
       let clickedElement = e.target as HTMLElement;
-      if (clickedElement.parentElement.classList.contains('document-entry')) {
+      if (clickedElement.parentElement?.classList.contains('document-entry')) {
         clickedElement = clickedElement.parentElement;
       }
 


### PR DESCRIPTION
Fix items 1 to 3 of Issue #147 (item 4 will be split into a separate issue)

## Root causes

1. **"Open" / "Move to Trash" silent**: their handlers early-return unless the action bar button is `active`, but the right-click path never calls `updateActionBarButtons()`, so the guard always fails.
2. **"Move" TypeError (12x)**: the main section click handler reads `clickedElement.parentElement.classList` without a null check; the element can already be detached from the DOM.
3. **"Put Back" TypeError**: `putBackDocsHandler` reads `recover_folder` metadata, which is only written by `removeDocsHandler` (dead per item 1). Files trashed via drag have no such metadata, so Put Back crashed on every file.

## Changes (3 small edits in `Dashboard.ts`)

1. Call `updateActionBarButtons()` after `select(index)` in the contextmenu listener. This also preserves the intended permissions for free: in Samples, Open works and Move to Trash stays disabled.
2. Optional chaining: `clickedElement.parentElement?.classList`.
3. `putBackDocsHandler` falls back to Home when `recover_folder` is missing.

Not addressed (noted in #147): the per-tile listener leak causing the 12x repetition, and the Rename divergence (item 4, separate issue).
