### PR TITLE
fix: rename tile never resolves and duplicate-name check compares wrong name

### DIFF
--- a/src/Dashboard/FileSystem/FileSystemTools.ts
+++ b/src/Dashboard/FileSystem/FileSystemTools.ts
@@ -152,9 +152,10 @@ const canRenameEntry = (
   parent: IFolder,
   newName: string,
 ): responseProp => {
-  // Check if newName already exists in parent
+  // Check if newName already exists in parent (any sibling other than the
+  // entry being renamed)
   const nameExists = parent.children.some(
-    (e, idx, arr) => e.name === entry.name && idx !== arr.indexOf(e),
+    (e) => e !== entry && e.name === newName,
   );
 
   const returnObj = { succeeded: false, error: '' };

--- a/src/Dashboard/Storage.ts
+++ b/src/Dashboard/Storage.ts
@@ -249,6 +249,7 @@ export function updateDocName(id: string, newName: string): Promise<boolean> {
         doc.name = newName;
         return db.put(doc);
       })
+      .then(() => resolve(true))
       .catch((err) => reject(err)); // db.get
   });
 }


### PR DESCRIPTION
Two bugs in the rename flow:

1. `updateDocName` (Storage.ts) built a promise that never resolved: `db.put` succeeded, but `resolve(true)` was never called, so the UI update chained on `.then()` never ran and the tile kept its old name until reload.
2. `canRenameEntry` (FileSystemTools.ts) compared siblings against the entry's *old* name instead of the requested `newName`, so renaming onto an existing sibling's name was never caught. The check now flags any sibling other than the entry itself whose name equals `newName`.

Tested: rename takes effect immediately and survives reload; renaming onto an existing name is blocked with the duplicate-name error.

Fixes #149
Fixes #147