### PR TITLE
chore: point frontend at lab-owned Worker and mappings index

### DIFF
--- a/src/Dashboard/cress-frontend-auth.ts
+++ b/src/Dashboard/cress-frontend-auth.ts
@@ -24,12 +24,12 @@
 /**
  * The deployed Worker URL.
  *
- * PoC (personal account): https://cress-auth.kyuchia.workers.dev
- * When the Worker moves to the lab Cloudflare account, change this to the
- * lab subdomain (e.g. https://cress-auth.ddmal.workers.dev). Code is otherwise
- * unchanged.
+ * The Worker runs on the lab-owned Cloudflare service account. This value must
+ * match the Worker's GITHUB_REDIRECT_URI secret and the OAuth App's
+ * Authorization callback URL exactly — GitHub compares the callback as a
+ * literal string, so a trailing slash breaks it.
  */
-const WORKER_URL = 'https://cress-auth.kyuchia.workers.dev';
+const WORKER_URL = 'https://cress-auth.ddmal.workers.dev';
 
 /**
  * The origin we expect token messages to come from. We verify event.origin

--- a/src/Dashboard/githubStorage/createMappingStorage.ts
+++ b/src/Dashboard/githubStorage/createMappingStorage.ts
@@ -111,9 +111,10 @@ export function resetMappingStorage(): void {
   _backend = null;
 }
 
-// Central index host during testing (personal account; see mappingsIndex.ts
-// for the ownership caveat and long-term plan).
-const INDEX_OWNER = 'kyuchia';
+// Owner of the central mappings index repo (users.csv), now held by the lab
+// service account. The old personal-account path still redirects, but that
+// redirect is not permanent — keep this in sync with the repo's real owner.
+const INDEX_OWNER = 'ddmaladmin';
 
 /**
  * Usernames known to the mappings index, excluding the logged-in user (their

--- a/src/Dashboard/githubStorage/mappingsIndex.ts
+++ b/src/Dashboard/githubStorage/mappingsIndex.ts
@@ -3,11 +3,11 @@
 // holding users.csv, one GitHub username per line. View-all resolves "which
 // users exist" by reading this list, then calls listForeignFiles per user.
 //
-// TEMPORARY OWNERSHIP: during testing the index lives under a personal account
-// and is curated by hand. Self-registration is deliberately avoided: it would
-// require cross-user writes to a shared repo, reintroducing the authz problem
-// the per-user-repo design removed. Long-term the index moves to the lab org
-// or is replaced by an automatic registration mechanism (see PR description).
+// OWNERSHIP: the index lives under a lab-owned service account and is curated
+// by hand. Self-registration is deliberately avoided: it would require
+// cross-user writes to a shared repo, reintroducing the authz problem the
+// per-user-repo design removed. Replacing the manual list with an automatic
+// registration mechanism remains open (see PR description).
 //
 // Deliberately NOT part of StorageBackend / ForeignReader: those are scoped to
 // mappings repos. The index is a different repo with a different lifecycle, so


### PR DESCRIPTION
Part of #167.

The auth Worker and the mappings index now live on the lab-owned service account, so the two frontend constants have to follow:

- `WORKER_URL` (`cress-frontend-auth.ts`)
- `INDEX_OWNER` (`createMappingStorage.ts`)

Also refreshes three comments that described the old arrangement: two said the setup was temporary and under a personal account, and one still pointed at the DDMAL org route, which was replaced by the service-account approach.

The OAuth App itself did not change: same app, same client ID, same authorized users. Only its owner and callback URL moved. 

Verified with a real login on the integration preview deployment: files list, All Mappings resolves other users through the new index path, console clean.